### PR TITLE
macos: interface in install

### DIFF
--- a/macos/install.sh
+++ b/macos/install.sh
@@ -25,6 +25,9 @@ if ! which wg > /dev/null; then
   cmd brew install wireguard-tools
 fi
 
+read -p "interface to listen on: "
+interface=${REPLY}
+
 info "installing launch daemon for innernet daemon script."
 echo "\
 <?xml version=\"1.0\" encoding=\"UTF-8\"?>
@@ -36,7 +39,8 @@ echo "\
     <key>ProgramArguments</key>
     <array>
       <string>/usr/local/bin/innernet</string>
-      <string>fetch</string>
+      <string>up</string>
+      <string>${interface}</string>
       <string>--daemon</string>
       <string>--interval</string>
       <string>60</string>


### PR DESCRIPTION
Looks like `fetch` is now `up`. Also, I needed to put an interface on the command line for innernet to work.

This is maybe not exactly the correct fix — at minimum the docs should be updated to say “kick the innernet launchd unit after you set up your interface”. Or perhaps `up` should listen on all interfaces on `/etc/innernet` or something.