### PR TITLE
bind innernet-server specifically to WireGuard interface on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,9 +680,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
+checksum = "56d855069fafbb9b344c0f962150cd2c1187975cb1c22c1522c240d8c4986714"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
+checksum = "5a3c91c24eae6777794bb1997ad98bbb87daf92890acab859f7eaa4320333176"
 dependencies = [
  "scopeguard",
 ]
@@ -929,9 +929,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
 dependencies = [
  "unicode-xid",
 ]
@@ -1130,6 +1130,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shared",
+ "socket2",
  "structopt",
  "tempfile",
  "thiserror",
@@ -1234,9 +1235,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6498a9efc342871f91cc2d0d694c674368b4ceb40f62b65a7a08c3792935e702"
+checksum = "3ce15dd3ed8aa2f8eeac4716d6ef5ab58b6b9256db41d7e1a0224c2788e8fd87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1329,9 +1330,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1551,8 +1552,7 @@ dependencies = [
 [[package]]
 name = "warp"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332d47745e9a0c38636dbd454729b147d16bd1ed08ae67b3ab281c4506771054"
+source = "git+https://github.com/tonarino/warp#bd70fb6249810eb63e9acdfe2dcc79e41ab53304"
 dependencies = [
  "bytes",
  "futures",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -3,10 +3,10 @@ authors = ["Jake McGinty <jake@tonari.no>"]
 description = "A client to manage innernet network interfaces."
 edition = "2018"
 homepage = "https://github.com/tonarino/innernet"
-repository = "https://github.com/tonarino/innernet"
 license = "MIT"
 name = "client"
 publish = false
+repository = "https://github.com/tonarino/innernet"
 version = "1.0.0"
 
 [[bin]]
@@ -18,7 +18,7 @@ colored = "2"
 dialoguer = "0.8"
 hostsfile = { path = "../hostsfile" }
 indoc = "1"
-ipnetwork = { git = "https://github.com/mcginty/ipnetwork" }
+ipnetwork = { git = "https://github.com/mcginty/ipnetwork" } # pending https://github.com/achanda/ipnetwork/pull/129
 lazy_static = "1"
 libc = "0.2"
 regex = { version = "1", default-features = false, features = ["std"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -19,7 +19,7 @@ dashmap = "4"
 dialoguer = "0.8"
 hyper = "0.14"
 indoc = "1"
-ipnetwork = { git = "https://github.com/mcginty/ipnetwork" }
+ipnetwork = { git = "https://github.com/mcginty/ipnetwork" } # pending https://github.com/achanda/ipnetwork/pull/129
 libc = "0.2"
 libsqlite3-sys = "0.20"
 log = "0.4"
@@ -34,7 +34,7 @@ structopt = "0.3"
 thiserror = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 toml = "0.5"
-warp = { git = "https://github.com/tonarino/warp", default-features = false }
+warp = { git = "https://github.com/tonarino/warp", default-features = false } # pending https://github.com/seanmonstar/warp/issues/830
 wgctrl = { path = "../wgctrl-rs" }
 
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -34,8 +34,12 @@ structopt = "0.3"
 thiserror = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 toml = "0.5"
-warp = { version = "0.3", default-features = false }
+warp = { git = "https://github.com/tonarino/warp", default-features = false }
 wgctrl = { path = "../wgctrl-rs" }
+
+
+[target.'cfg(target_os = "linux")'.dependencies]
+socket2 = { version = "0.4", features = ["all"] }
 
 [dev-dependencies]
 anyhow = "1"

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -327,6 +327,12 @@ async fn serve(interface: &str, conf: &ServerConfig) -> Result<(), Error> {
     Ok(())
 }
 
+/// This function differs per OS, because different operating systems have
+/// opposing characteristics when binding to a specific IP address.
+/// On Linux, binding to a specific local IP address does *not* bind it to
+/// that IP's interface, allowing for spoofing attacks.
+///
+/// See https://github.com/tonarino/innernet/issues/26 for more details.
 #[cfg(target_os = "linux")]
 fn get_listener(addr: SocketAddr, interface: &str) -> Result<TcpListener, Error> {
     let listener = TcpListener::bind(&addr)?;
@@ -336,6 +342,12 @@ fn get_listener(addr: SocketAddr, interface: &str) -> Result<TcpListener, Error>
     Ok(sock.into())
 }
 
+/// BSD-likes do seem to bind to an interface when binding to an IP,
+/// according to the internet, but we may want to explicitly use
+/// IP_BOUND_IF in the future regardless. This isn't currently in
+/// the socket2 crate however, so we aren't currently using it.
+///
+/// See https://github.com/tonarino/innernet/issues/26 for more details.
 #[cfg(not(target_os = "linux"))]
 fn get_listener(addr: SocketAddr, _interface: &str) -> Result<TcpListener, Error> {
     let listener = TcpListener::bind(&addr)?;

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -10,7 +10,7 @@ version = "1.0.0"
 colored = "2.0"
 dialoguer = "0.8"
 indoc = "1"
-ipnetwork = { git = "https://github.com/mcginty/ipnetwork" }
+ipnetwork = { git = "https://github.com/mcginty/ipnetwork" } # pending https://github.com/achanda/ipnetwork/pull/129
 lazy_static = "1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }

--- a/wgctrl-rs/Cargo.toml
+++ b/wgctrl-rs/Cargo.toml
@@ -19,5 +19,5 @@ wgctrl-sys = { path = "../wgctrl-sys" }
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
 rand_core = "0.6"
-x25519-dalek = { git = "https://github.com/mcginty/x25519-dalek", branch = "master" }
 subtle = "2"
+x25519-dalek = { git = "https://github.com/mcginty/x25519-dalek", branch = "master" } # pending https://github.com/dalek-cryptography/x25519-dalek/pull/64


### PR DESCRIPTION
This is one many upcoming changes to address IP spoofing issues.

See #26 for more details.