### PR TITLE
Remove some unsafe in the wgctrl-sys kernel backend

### DIFF
--- a/client/src/data_store.rs
+++ b/client/src/data_store.rs
@@ -6,6 +6,7 @@ use std::{
     io::{Read, Seek, SeekFrom, Write},
     path::Path,
 };
+use wgctrl::InterfaceName;
 
 #[derive(Debug)]
 pub struct DataStore {
@@ -38,19 +39,21 @@ impl DataStore {
         Ok(Self { file, contents })
     }
 
-    fn _open(interface: &str, create: bool) -> Result<Self, Error> {
+    fn _open(interface: &InterfaceName, create: bool) -> Result<Self, Error> {
         ensure_dirs_exist(&[*CLIENT_DATA_PATH])?;
         Self::open_with_path(
-            CLIENT_DATA_PATH.join(interface).with_extension("json"),
+            CLIENT_DATA_PATH
+                .join(interface.to_string())
+                .with_extension("json"),
             create,
         )
     }
 
-    pub fn open(interface: &str) -> Result<Self, Error> {
+    pub fn open(interface: &InterfaceName) -> Result<Self, Error> {
         Self::_open(interface, false)
     }
 
-    pub fn open_or_create(interface: &str) -> Result<Self, Error> {
+    pub fn open_or_create(interface: &InterfaceName) -> Result<Self, Error> {
         Self::_open(interface, true)
     }
 

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -8,13 +8,14 @@ use shared::{
     REDEEM_TRANSITION_WAIT,
 };
 use std::{
+    convert::TryInto,
     fmt,
     path::{Path, PathBuf},
     thread,
     time::Duration,
 };
 use structopt::StructOpt;
-use wgctrl::{DeviceConfigBuilder, DeviceInfo, PeerConfigBuilder, PeerInfo};
+use wgctrl::{DeviceConfigBuilder, DeviceInfo, InterfaceName, PeerConfigBuilder, PeerInfo};
 
 mod data_store;
 mod util;
@@ -155,7 +156,11 @@ impl std::error::Error for ClientError {
     }
 }
 
-fn update_hosts_file(interface: &str, hosts_path: PathBuf, peers: &Vec<Peer>) -> Result<(), Error> {
+fn update_hosts_file(
+    interface: &InterfaceName,
+    hosts_path: PathBuf,
+    peers: &Vec<Peer>,
+) -> Result<(), Error> {
     println!(
         "{} updating {} with the latest peers.",
         "[*]".dimmed(),
@@ -188,6 +193,8 @@ fn install(invite: &Path, hosts_file: Option<PathBuf>) -> Result<(), Error> {
     if target_conf.exists() {
         return Err("An interface with this name already exists in innernet.".into());
     }
+
+    let iface = iface.as_str().try_into()?;
 
     println!("{} bringing up the interface.", "[*]".dimmed());
     wg::up(
@@ -267,7 +274,7 @@ fn install(invite: &Path, hosts_file: Option<PathBuf>) -> Result<(), Error> {
 
     ",
         star = "[*]".dimmed(),
-        interface = iface.yellow(),
+        interface = iface.to_string().yellow(),
         installed = "installed".green(),
         systemctl_enable = "systemctl enable --now innernet@".yellow(),
     );
@@ -276,7 +283,7 @@ fn install(invite: &Path, hosts_file: Option<PathBuf>) -> Result<(), Error> {
 }
 
 fn up(
-    interface: &str,
+    interface: &InterfaceName,
     loop_interval: Option<Duration>,
     hosts_path: Option<PathBuf>,
 ) -> Result<(), Error> {
@@ -292,7 +299,7 @@ fn up(
 }
 
 fn fetch(
-    interface: &str,
+    interface: &InterfaceName,
     bring_up_interface: bool,
     hosts_path: Option<PathBuf>,
 ) -> Result<(), Error> {
@@ -398,7 +405,7 @@ fn fetch(
         println!(
             "\n{} updated interface {}\n",
             "[*]".dimmed(),
-            interface.yellow()
+            interface.as_str_lossy().yellow()
         );
     } else {
         println!("{}", "    peers are already up to date.".green());
@@ -410,7 +417,7 @@ fn fetch(
     Ok(())
 }
 
-fn add_cidr(interface: &str) -> Result<(), Error> {
+fn add_cidr(interface: &InterfaceName) -> Result<(), Error> {
     let InterfaceConfig { server, .. } = InterfaceConfig::from_interface(interface)?;
     println!("Fetching CIDRs");
     let cidrs: Vec<Cidr> = http_get(&server.internal_endpoint, "/admin/cidrs")?;
@@ -435,7 +442,7 @@ fn add_cidr(interface: &str) -> Result<(), Error> {
     Ok(())
 }
 
-fn add_peer(interface: &str) -> Result<(), Error> {
+fn add_peer(interface: &InterfaceName) -> Result<(), Error> {
     let InterfaceConfig { server, .. } = InterfaceConfig::from_interface(interface)?;
     println!("Fetching CIDRs");
     let cidrs: Vec<Cidr> = http_get(&server.internal_endpoint, "/admin/cidrs")?;
@@ -462,7 +469,7 @@ fn add_peer(interface: &str) -> Result<(), Error> {
     Ok(())
 }
 
-fn enable_or_disable_peer(interface: &str, enable: bool) -> Result<(), Error> {
+fn enable_or_disable_peer(interface: &InterfaceName, enable: bool) -> Result<(), Error> {
     let InterfaceConfig { server, .. } = InterfaceConfig::from_interface(interface)?;
     println!("Fetching peers.");
     let peers: Vec<Peer> = http_get(&server.internal_endpoint, "/admin/peers")?;
@@ -482,7 +489,7 @@ fn enable_or_disable_peer(interface: &str, enable: bool) -> Result<(), Error> {
     Ok(())
 }
 
-fn add_association(interface: &str) -> Result<(), Error> {
+fn add_association(interface: &InterfaceName) -> Result<(), Error> {
     let InterfaceConfig { server, .. } = InterfaceConfig::from_interface(interface)?;
 
     println!("Fetching CIDRs");
@@ -504,7 +511,7 @@ fn add_association(interface: &str) -> Result<(), Error> {
     Ok(())
 }
 
-fn delete_association(interface: &str) -> Result<(), Error> {
+fn delete_association(interface: &InterfaceName) -> Result<(), Error> {
     let InterfaceConfig { server, .. } = InterfaceConfig::from_interface(interface)?;
 
     println!("Fetching CIDRs");
@@ -525,7 +532,7 @@ fn delete_association(interface: &str) -> Result<(), Error> {
     Ok(())
 }
 
-fn list_associations(interface: &str) -> Result<(), Error> {
+fn list_associations(interface: &InterfaceName) -> Result<(), Error> {
     let InterfaceConfig { server, .. } = InterfaceConfig::from_interface(interface)?;
     println!("Fetching CIDRs");
     let cidrs: Vec<Cidr> = http_get(&server.internal_endpoint, "/admin/cidrs")?;
@@ -555,7 +562,7 @@ fn list_associations(interface: &str) -> Result<(), Error> {
     Ok(())
 }
 
-fn set_listen_port(interface: &str, unset: bool) -> Result<(), Error> {
+fn set_listen_port(interface: &InterfaceName, unset: bool) -> Result<(), Error> {
     let mut config = InterfaceConfig::from_interface(interface)?;
 
     if let Some(listen_port) = prompts::set_listen_port(&config.interface, unset)? {
@@ -572,7 +579,7 @@ fn set_listen_port(interface: &str, unset: bool) -> Result<(), Error> {
     Ok(())
 }
 
-fn override_endpoint(interface: &str, unset: bool) -> Result<(), Error> {
+fn override_endpoint(interface: &InterfaceName, unset: bool) -> Result<(), Error> {
     let config = InterfaceConfig::from_interface(interface)?;
     if !unset && config.interface.listen_port.is_none() {
         println!(
@@ -597,10 +604,8 @@ fn override_endpoint(interface: &str, unset: bool) -> Result<(), Error> {
 }
 
 fn show(short: bool, tree: bool, interface: Option<Interface>) -> Result<(), Error> {
-    let interfaces = interface.map_or_else(
-        || DeviceInfo::enumerate(),
-        |interface| Ok(vec![interface.to_string()]),
-    )?;
+    let interfaces =
+        interface.map_or_else(|| DeviceInfo::enumerate(), |interface| Ok(vec![*interface]))?;
 
     let devices = interfaces.into_iter().filter_map(|name| {
         DataStore::open(&name)

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -8,7 +8,6 @@ use shared::{
     REDEEM_TRANSITION_WAIT,
 };
 use std::{
-    convert::TryInto,
     fmt,
     path::{Path, PathBuf},
     thread,
@@ -194,7 +193,7 @@ fn install(invite: &Path, hosts_file: Option<PathBuf>) -> Result<(), Error> {
         return Err("An interface with this name already exists in innernet.".into());
     }
 
-    let iface = iface.as_str().try_into()?;
+    let iface = iface.parse()?;
 
     println!("{} bringing up the interface.", "[*]".dimmed());
     wg::up(

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -678,7 +678,7 @@ fn print_interface(device_info: &DeviceInfo, me: &Peer, short: bool) -> Result<(
         .to_base64();
 
     if short {
-        println!("{}", device_info.name.green().bold());
+        println!("{}", device_info.name.to_string().green().bold());
         println!(
             "  {} {}: {} ({}...)",
             "(you)".bold(),
@@ -690,7 +690,7 @@ fn print_interface(device_info: &DeviceInfo, me: &Peer, short: bool) -> Result<(
         println!(
             "{}: {} ({}...)",
             "interface".green().bold(),
-            device_info.name.green(),
+            device_info.name.to_string().green(),
             public_key[..10].yellow()
         );
         if !short {

--- a/server/src/endpoints.rs
+++ b/server/src/endpoints.rs
@@ -1,6 +1,6 @@
 use crossbeam::channel::{self, select};
 use dashmap::DashMap;
-use wgctrl::DeviceInfo;
+use wgctrl::{DeviceInfo, InterfaceName};
 
 use std::{io, net::SocketAddr, sync::Arc, thread, time::Duration};
 
@@ -18,7 +18,7 @@ impl std::ops::Deref for Endpoints {
 }
 
 impl Endpoints {
-    pub fn new(iface: &str) -> Result<Self, io::Error> {
+    pub fn new(iface: &InterfaceName) -> Result<Self, io::Error> {
         let endpoints = Arc::new(DashMap::new());
         let (stop_tx, stop_rx) = channel::bounded(1);
 

--- a/server/src/initialize.rs
+++ b/server/src/initialize.rs
@@ -1,3 +1,5 @@
+use std::convert::TryInto;
+
 use crate::*;
 use db::DatabaseCidr;
 use dialoguer::{theme::ColorfulTheme, Input};
@@ -100,6 +102,9 @@ pub fn init_wizard(conf: &ServerConfig) -> Result<(), Error> {
         (name, root_cidr)
     });
 
+    // This probably won't error because of the `hostname_validator` regex.
+    let name = name.as_str().try_into()?;
+
     let endpoint: SocketAddr = conf.endpoint.unwrap_or_else(|| {
         prompts::ask_endpoint()
             .map_err(|_| println!("failed to get endpoint."))
@@ -131,7 +136,7 @@ pub fn init_wizard(conf: &ServerConfig) -> Result<(), Error> {
     config.write_to_path(&config_path)?;
 
     let db_init_data = DbInitData {
-        root_cidr_name: name.clone(),
+        root_cidr_name: name.to_string(),
         root_cidr,
         server_cidr,
         our_ip,
@@ -176,7 +181,7 @@ pub fn init_wizard(conf: &ServerConfig) -> Result<(), Error> {
 
     ",
         star = "[*]".dimmed(),
-        interface = name.yellow(),
+        interface = name.to_string().yellow(),
         created = "created".green(),
         wg_manage_server = "innernet-server".yellow(),
         add_cidr = "add-cidr".yellow(),

--- a/server/src/initialize.rs
+++ b/server/src/initialize.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 use crate::*;
 use db::DatabaseCidr;
 use dialoguer::{theme::ColorfulTheme, Input};
@@ -103,7 +101,7 @@ pub fn init_wizard(conf: &ServerConfig) -> Result<(), Error> {
     });
 
     // This probably won't error because of the `hostname_validator` regex.
-    let name = name.as_str().try_into()?;
+    let name = name.parse()?;
 
     let endpoint: SocketAddr = conf.endpoint.unwrap_or_else(|| {
         prompts::ask_endpoint()

--- a/server/src/test.rs
+++ b/server/src/test.rs
@@ -12,7 +12,7 @@ use shared::{Cidr, CidrContents, PeerContents};
 use std::{net::SocketAddr, path::PathBuf, sync::Arc};
 use tempfile::TempDir;
 use warp::test::RequestBuilder;
-use wgctrl::KeyPair;
+use wgctrl::{InterfaceName, KeyPair};
 
 pub const ROOT_CIDR: &str = "10.80.0.0/15";
 pub const SERVER_CIDR: &str = "10.80.0.1/32";
@@ -45,7 +45,7 @@ pub const USER2_PEER_ID: i64 = 6;
 pub struct Server {
     pub db: Arc<Mutex<Connection>>,
     endpoints: Arc<Endpoints>,
-    interface: String,
+    interface: InterfaceName,
     conf: ServerConfig,
     // The directory will be removed during destruction.
     _test_dir: TempDir,
@@ -69,6 +69,7 @@ impl Server {
         };
         init_wizard(&conf).map_err(|_| anyhow!("init_wizard failed"))?;
 
+        let interface = interface.parse().unwrap();
         // Add developer CIDR and user CIDR and some peers for testing.
         let db = Connection::open(&conf.database_path(&interface))?;
         db.pragma_update(None, "foreign_keys", &1)?;

--- a/shared/src/interface_config.rs
+++ b/shared/src/interface_config.rs
@@ -9,6 +9,7 @@ use std::{
     os::unix::fs::PermissionsExt,
     path::{Path, PathBuf},
 };
+use wgctrl::InterfaceName;
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "kebab-case")]
@@ -92,7 +93,7 @@ impl InterfaceConfig {
     }
 
     /// Overwrites the config file if it already exists.
-    pub fn write_to_interface(&self, interface: &str) -> Result<PathBuf, Error> {
+    pub fn write_to_interface(&self, interface: &InterfaceName) -> Result<PathBuf, Error> {
         let path = Self::build_config_file_path(interface)?;
         File::create(&path)
             .with_path(&path)?
@@ -104,13 +105,15 @@ impl InterfaceConfig {
         Ok(toml::from_slice(&std::fs::read(&path).with_path(path)?)?)
     }
 
-    pub fn from_interface(interface: &str) -> Result<Self, Error> {
+    pub fn from_interface(interface: &InterfaceName) -> Result<Self, Error> {
         Self::from_file(Self::build_config_file_path(interface)?)
     }
 
-    fn build_config_file_path(interface: &str) -> Result<PathBuf, Error> {
+    fn build_config_file_path(interface: &InterfaceName) -> Result<PathBuf, Error> {
         ensure_dirs_exist(&[*CLIENT_CONFIG_PATH])?;
-        Ok(CLIENT_CONFIG_PATH.join(interface).with_extension("conf"))
+        Ok(CLIENT_CONFIG_PATH
+            .join(interface.to_string())
+            .with_extension("conf"))
     }
 }
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -3,7 +3,6 @@ use lazy_static::lazy_static;
 use prompts::hostname_validator;
 use serde::{Deserialize, Serialize};
 use std::{
-    convert::TryInto,
     fmt::{Display, Formatter},
     fs::{self, File},
     io,
@@ -76,8 +75,7 @@ impl FromStr for Interface {
         let name = name.to_string();
         hostname_validator(&name)?;
         let name = name
-            .as_str()
-            .try_into()
+            .parse()
             .map_err(|e: InvalidInterfaceName| e.to_string())?;
         Ok(Self { name })
     }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -365,7 +365,7 @@ pub fn ensure_dirs_exist(dirs: &[&Path]) -> Result<(), Error> {
                 let metadata = target_file.metadata().with_path(dir)?;
                 let mut permissions = metadata.permissions();
                 permissions.set_mode(0o700);
-            },
+            }
             Err(e) if e.kind() != io::ErrorKind::AlreadyExists => {
                 return Err(e.into());
             },

--- a/shared/src/prompts.rs
+++ b/shared/src/prompts.rs
@@ -9,7 +9,7 @@ use ipnetwork::IpNetwork;
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::net::{IpAddr, SocketAddr};
-use wgctrl::KeyPair;
+use wgctrl::{InterfaceName, KeyPair};
 
 lazy_static! {
     static ref THEME: ColorfulTheme = ColorfulTheme::default();
@@ -239,7 +239,7 @@ pub fn enable_or_disable_peer(peers: &[Peer], enable: bool) -> Result<Option<Pee
 
 /// Confirm and write a innernet invitation file after a peer has been created.
 pub fn save_peer_invitation(
-    network_name: &str,
+    network_name: &InterfaceName,
     peer: &Peer,
     server_peer: &Peer,
     root_cidr: &Cidr,

--- a/shared/src/wg.rs
+++ b/shared/src/wg.rs
@@ -1,10 +1,7 @@
 use crate::{Error, IoErrorContext};
 use ipnetwork::IpNetwork;
-use std::{
-    net::{IpAddr, SocketAddr},
-    process::{self, Command},
-};
-use wgctrl::{DeviceConfigBuilder, PeerConfigBuilder};
+use std::{convert::TryFrom, net::{IpAddr, SocketAddr}, process::{self, Command}};
+use wgctrl::{DeviceConfigBuilder, InterfaceName, PeerConfigBuilder};
 
 fn cmd(bin: &str, args: &[&str]) -> Result<process::Output, Error> {
     let output = Command::new(bin).args(args).output()?;
@@ -99,7 +96,8 @@ pub fn set_listen_port(interface: &str, listen_port: Option<u16>) -> Result<(), 
 
 #[cfg(target_os = "linux")]
 pub fn down(interface: &str) -> Result<(), Error> {
-    Ok(wgctrl::delete_interface(interface).with_str(interface)?)
+    let interface = InterfaceName::try_from(interface)?;
+    Ok(wgctrl::delete_interface(&interface).with_str(interface.to_string())?)
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/wgctrl-rs/src/backends/kernel.rs
+++ b/wgctrl-rs/src/backends/kernel.rs
@@ -1,7 +1,4 @@
-use crate::{
-    device::AllowedIp, DeviceConfigBuilder, DeviceInfo, InvalidKey, PeerConfig, PeerConfigBuilder,
-    PeerInfo, PeerStats,
-};
+use crate::{DeviceConfigBuilder, DeviceInfo, InterfaceName, InvalidKey, PeerConfig, PeerConfigBuilder, PeerInfo, PeerStats, device::AllowedIp};
 use wgctrl_sys::{timespec64, wg_device_flags as wgdf, wg_peer_flags as wgpf};
 
 use std::{
@@ -71,8 +68,10 @@ impl<'a> From<&'a wgctrl_sys::wg_peer> for PeerInfo {
 
 impl<'a> From<&'a wgctrl_sys::wg_device> for DeviceInfo {
     fn from(raw: &wgctrl_sys::wg_device) -> DeviceInfo {
+        // SAFETY: The name string buffer came directly from wgctrl so its NUL terminated.
+        let name = unsafe { InterfaceName::from_wg(raw.name) };
         DeviceInfo {
-            name: parse_device_name(raw.name),
+            name,
             public_key: if (raw.flags & wgdf::WGDEVICE_HAS_PUBLIC_KEY).0 > 0 {
                 Some(Key::from_raw(raw.public_key))
             } else {
@@ -96,15 +95,6 @@ impl<'a> From<&'a wgctrl_sys::wg_device> for DeviceInfo {
             __cant_construct_me: (),
         }
     }
-}
-
-fn parse_device_name(name: [c_char; 16]) -> String {
-    let name: &[u8; 16] = unsafe { &*((&name) as *const _ as *const [u8; 16]) };
-    let idx: usize = name
-        .iter()
-        .position(|x| *x == 0)
-        .expect("Interface name too long?");
-    unsafe { str::from_utf8_unchecked(&name[..idx]) }.to_owned()
 }
 
 fn parse_peers(dev: &wgctrl_sys::wg_device) -> Vec<PeerInfo> {
@@ -297,15 +287,6 @@ fn encode_peers(
     (first_peer, last_peer)
 }
 
-fn encode_name(name: &str) -> [c_char; 16] {
-    let slice = unsafe { &*(name.as_bytes() as *const _ as *const [c_char]) };
-
-    let mut result = [c_char::default(); 16];
-    result[..slice.len()].copy_from_slice(slice);
-
-    result
-}
-
 pub fn exists() -> bool {
     // Try to load the wireguard module if it isn't already.
     // This is only called once per lifetime of the process.
@@ -348,18 +329,17 @@ pub fn enumerate() -> Result<Vec<String>, io::Error> {
     Ok(result)
 }
 
-pub fn apply(builder: DeviceConfigBuilder, iface: &str) -> io::Result<()> {
+pub fn apply(builder: DeviceConfigBuilder, iface: &InterfaceName) -> io::Result<()> {
     let (first_peer, last_peer) = encode_peers(builder.peers);
 
-    let iface_str = CString::new(iface)?;
-    let result = unsafe { wgctrl_sys::wg_add_device(iface_str.as_ptr()) };
+    let result = unsafe { wgctrl_sys::wg_add_device(iface.as_ptr()) };
     match result {
         0 | -17 => {},
         _ => return Err(io::Error::last_os_error()),
     };
 
     let mut wg_device = Box::new(wgctrl_sys::wg_device {
-        name: encode_name(iface),
+        name: iface.into_inner(),
         ifindex: 0,
         public_key: wgctrl_sys::wg_key::default(),
         private_key: wgctrl_sys::wg_key::default(),
@@ -406,15 +386,13 @@ pub fn apply(builder: DeviceConfigBuilder, iface: &str) -> io::Result<()> {
     }
 }
 
-pub fn get_by_name(name: &str) -> Result<DeviceInfo, io::Error> {
+pub fn get_by_name(name: &InterfaceName) -> Result<DeviceInfo, io::Error> {
     let mut device: *mut wgctrl_sys::wg_device = ptr::null_mut();
-
-    let cs = CString::new(name)?;
 
     let result = unsafe {
         wgctrl_sys::wg_get_device(
             (&mut device) as *mut _ as *mut *mut wgctrl_sys::wg_device,
-            cs.as_ptr(),
+            name.as_ptr(),
         )
     };
 
@@ -429,9 +407,8 @@ pub fn get_by_name(name: &str) -> Result<DeviceInfo, io::Error> {
     result
 }
 
-pub fn delete_interface(iface: &str) -> io::Result<()> {
-    let iface_str = CString::new(iface)?;
-    let result = unsafe { wgctrl_sys::wg_del_device(iface_str.as_ptr()) };
+pub fn delete_interface(iface: &InterfaceName) -> io::Result<()> {
+    let result = unsafe { wgctrl_sys::wg_del_device(iface.as_ptr()) };
 
     if result == 0 {
         Ok(())

--- a/wgctrl-rs/src/backends/kernel.rs
+++ b/wgctrl-rs/src/backends/kernel.rs
@@ -5,7 +5,6 @@ use crate::{
 use wgctrl_sys::{timespec64, wg_device_flags as wgdf, wg_peer_flags as wgpf};
 
 use std::{
-    convert::TryInto,
     ffi::{CStr, CString},
     io,
     net::{IpAddr, SocketAddr},
@@ -328,7 +327,7 @@ pub fn enumerate() -> Result<Vec<InterfaceName>, io::Error> {
 
         let interface: InterfaceName = str::from_utf8(next_dev)
             .map_err(|_| InvalidInterfaceName::InvalidChars)?
-            .try_into()?;
+            .parse()?;
 
         result.push(interface);
     }

--- a/wgctrl-rs/src/backends/userspace.rs
+++ b/wgctrl-rs/src/backends/userspace.rs
@@ -4,7 +4,6 @@ use crate::{DeviceConfigBuilder, DeviceInfo, InterfaceName, PeerConfig, PeerInfo
 use crate::Key;
 
 use std::{
-    convert::TryInto,
     fs,
     io::{self, prelude::*, BufReader},
     os::unix::net::UnixStream,
@@ -62,7 +61,7 @@ pub fn enumerate() -> Result<Vec<InterfaceName>, io::Error> {
         if path.extension() == Some(OsStr::new("name")) {
             let stem = path.file_stem().map(|stem| stem.to_str()).flatten();
             if let Some(name) = stem {
-                interfaces.push(name.try_into()?);
+                interfaces.push(name.parse()?);
             }
         }
     }

--- a/wgctrl-rs/src/config.rs
+++ b/wgctrl-rs/src/config.rs
@@ -1,13 +1,10 @@
 use crate::{
     backends,
-    device::{AllowedIp, PeerConfig},
+    device::{AllowedIp, InterfaceName, PeerConfig},
     key::{Key, KeyPair},
 };
 
-use std::{
-    io,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
-};
+use std::{convert::TryInto, io, net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr}};
 
 /// Builds and represents a configuration that can be applied to a WireGuard interface.
 ///
@@ -173,7 +170,8 @@ impl DeviceConfigBuilder {
     #[cfg(target_os = "linux")]
     pub fn apply(self, iface: &str) -> io::Result<()> {
         if backends::kernel::exists() {
-            backends::kernel::apply(self, iface)
+            let iface = iface.try_into()?;
+            backends::kernel::apply(self, &iface)
         } else {
             backends::userspace::apply(self, iface)
         }
@@ -353,6 +351,6 @@ impl PeerConfigBuilder {
 
 /// Deletes an existing WireGuard interface by name.
 #[cfg(target_os = "linux")]
-pub fn delete_interface(iface: &str) -> io::Result<()> {
+pub fn delete_interface(iface: &InterfaceName) -> io::Result<()> {
     backends::kernel::delete_interface(iface)
 }

--- a/wgctrl-rs/src/config.rs
+++ b/wgctrl-rs/src/config.rs
@@ -35,7 +35,7 @@ use std::{
 ///         peer.set_endpoint(server_addr)
 ///             .replace_allowed_ips()
 ///             .allow_all_ips()
-///     }).apply("wg-example");
+///     }).apply(&"wg-example".parse().unwrap());
 ///
 /// println!("Send these keys to your peer: {:#?}", peer_keypair);
 ///
@@ -215,7 +215,7 @@ impl Default for DeviceConfigBuilder {
 ///     .add_allowed_ip("192.168.1.2".parse()?, 32);
 ///
 /// // update our existing configuration with the new peer
-/// DeviceConfigBuilder::new().add_peer(peer).apply("wg-example");
+/// DeviceConfigBuilder::new().add_peer(peer).apply(&"wg-example".parse().unwrap());
 ///
 /// println!("Send these keys to your peer: {:#?}", peer_keypair);
 ///

--- a/wgctrl-rs/src/config.rs
+++ b/wgctrl-rs/src/config.rs
@@ -4,7 +4,10 @@ use crate::{
     key::{Key, KeyPair},
 };
 
-use std::{convert::TryInto, io, net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr}};
+use std::{
+    io,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+};
 
 /// Builds and represents a configuration that can be applied to a WireGuard interface.
 ///
@@ -168,9 +171,8 @@ impl DeviceConfigBuilder {
     ///
     /// An interface with the provided name will be created if one does not exist already.
     #[cfg(target_os = "linux")]
-    pub fn apply(self, iface: &str) -> io::Result<()> {
+    pub fn apply(self, iface: &InterfaceName) -> io::Result<()> {
         if backends::kernel::exists() {
-            let iface = iface.try_into()?;
             backends::kernel::apply(self, &iface)
         } else {
             backends::userspace::apply(self, iface)
@@ -178,7 +180,7 @@ impl DeviceConfigBuilder {
     }
 
     #[cfg(not(target_os = "linux"))]
-    pub fn apply(self, iface: &str) -> io::Result<()> {
+    pub fn apply(self, iface: &InterfaceName) -> io::Result<()> {
         backends::userspace::apply(self, iface)
     }
 }


### PR DESCRIPTION
After reading the code a bit, I saw a bit of unsafe that caught my eye.

The previous device name parsing could potentially lead to UB since it doesn't look like Wireguard nor Netlink care about if the interface name is valid ASCII or UTF-8 and `str::from_utf8_unchecked` was being used. I made an `InterfaceName` wrapper struct to help validate interface names better and to ensure nothing weird happens passing the interface name around.

It also made converting the interface names cheaper since its just copies some bytes now. I also added some basic validation for interface name creation to prevent data that's going to be rejected anyway from making it across the FFI. As part of the newtype I moved the magic `16` constant to use the same `libc` constant that the Wireguard headers do for interfaces max length.

Also thanks for open sourcing this, its a very cool project and I look forward to using it in one of my setups :D