### PR TITLE
Simple CSRF solution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,6 +1132,7 @@ dependencies = [
  "shared",
  "socket2",
  "structopt",
+ "subtle",
  "tempfile",
  "thiserror",
  "tokio",

--- a/client/src/util.rs
+++ b/client/src/util.rs
@@ -75,12 +75,17 @@ impl<'a> Api<'a> {
         endpoint: &str,
         form: Option<S>,
     ) -> Result<T, Error> {
-        let response = ureq::request(
+        let request = ureq::request(
             verb,
             &format!("http://{}/v1{}", self.server.internal_endpoint, endpoint),
         )
-        .set(INNERNET_PUBKEY_HEADER, &self.server.public_key)
-        .send_json(serde_json::to_value(form)?)?;
+        .set(INNERNET_PUBKEY_HEADER, &self.server.public_key);
+
+        let response = if let Some(form) = form {
+            request.send_json(serde_json::to_value(form)?)?
+        } else {
+            request.call()?
+        };
 
         let mut response = response.into_string()?;
         // A little trick for serde to parse an empty response as `()`.

--- a/client/src/util.rs
+++ b/client/src/util.rs
@@ -1,7 +1,8 @@
 use crate::{ClientError, Error};
 use colored::*;
 use serde::{de::DeserializeOwned, Serialize};
-use std::{net::SocketAddr, time::Duration};
+use shared::{interface_config::ServerInfo, INNERNET_PUBKEY_HEADER};
+use std::time::Duration;
 
 pub fn human_duration(duration: Duration) -> String {
     match duration.as_secs() {
@@ -46,41 +47,51 @@ pub fn human_size(bytes: u64) -> String {
     }
 }
 
-pub fn http_get<T: DeserializeOwned>(server: &SocketAddr, endpoint: &str) -> Result<T, Error> {
-    let response = ureq::get(&format!("http://{}/v1{}", server, endpoint)).call()?;
-    process_response(response)
+pub struct Api<'a> {
+    server: &'a ServerInfo,
 }
 
-pub fn http_delete(server: &SocketAddr, endpoint: &str) -> Result<(), Error> {
-    ureq::get(&format!("http://{}/v1{}", server, endpoint)).call()?;
-    Ok(())
-}
-
-pub fn http_post<S: Serialize, D: DeserializeOwned>(
-    server: &SocketAddr,
-    endpoint: &str,
-    form: S,
-) -> Result<D, Error> {
-    let response = ureq::post(&format!("http://{}/v1{}", server, endpoint))
-        .send_json(serde_json::to_value(form)?)?;
-    process_response(response)
-}
-
-pub fn http_put<S: Serialize>(server: &SocketAddr, endpoint: &str, form: S) -> Result<(), Error> {
-    ureq::put(&format!("http://{}/v1{}", server, endpoint))
-        .send_json(serde_json::to_value(form)?)?;
-    Ok(())
-}
-
-fn process_response<T: DeserializeOwned>(response: ureq::Response) -> Result<T, Error> {
-    let mut response = response.into_string()?;
-    if response.is_empty() {
-        response = "null".into();
+impl<'a> Api<'a> {
+    pub fn new(server: &'a ServerInfo) -> Self {
+        Self { server }
     }
-    Ok(serde_json::from_str(&response).map_err(|e| {
-        ClientError(format!(
-            "failed to deserialize JSON response from the server: {}, response={}",
-            e, &response
-        ))
-    })?)
+
+    pub fn http<T: DeserializeOwned>(&self, verb: &str, endpoint: &str) -> Result<T, Error> {
+        self.request::<(), _>(verb, endpoint, None)
+    }
+
+    pub fn http_form<S: Serialize, T: DeserializeOwned>(
+        &self,
+        verb: &str,
+        endpoint: &str,
+        form: S,
+    ) -> Result<T, Error> {
+        self.request(verb, endpoint, Some(form))
+    }
+
+    fn request<S: Serialize, T: DeserializeOwned>(
+        &self,
+        verb: &str,
+        endpoint: &str,
+        form: Option<S>,
+    ) -> Result<T, Error> {
+        let response = ureq::request(
+            verb,
+            &format!("http://{}/v1{}", self.server.internal_endpoint, endpoint),
+        )
+        .set(INNERNET_PUBKEY_HEADER, &self.server.public_key)
+        .send_json(serde_json::to_value(form)?)?;
+
+        let mut response = response.into_string()?;
+        // A little trick for serde to parse an empty response as `()`.
+        if response.is_empty() {
+            response = "null".into();
+        }
+        Ok(serde_json::from_str(&response).map_err(|e| {
+            ClientError(format!(
+                "failed to deserialize JSON response from the server: {}, response={}",
+                e, &response
+            ))
+        })?)
+    }
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -30,6 +30,7 @@ rusqlite = "0.24"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 shared = { path = "../shared" }
+subtle = "2"
 structopt = "0.3"
 thiserror = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/server/src/api/admin/cidr.rs
+++ b/server/src/api/admin/cidr.rs
@@ -104,7 +104,8 @@ mod tests {
         };
 
         let filter = crate::routes(server.context());
-        let res = server.post_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server
+            .post_request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/cidrs")
             .body(serde_json::to_string(&contents)?)
             .reply(&filter)
@@ -132,7 +133,8 @@ mod tests {
         };
 
         let filter = crate::routes(server.context());
-        let res = server.post_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server
+            .post_request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/cidrs")
             .body(serde_json::to_string(&contents)?)
             .reply(&filter)
@@ -145,7 +147,8 @@ mod tests {
             cidr: test::EXPERIMENTAL_SUBCIDR.parse()?,
             parent: Some(cidr_res.id),
         };
-        let res = server.post_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server
+            .post_request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/cidrs")
             .body(serde_json::to_string(&contents)?)
             .reply(&filter)
@@ -166,7 +169,8 @@ mod tests {
         };
 
         let filter = crate::routes(server.context());
-        let res = server.post_request_from_ip(test::USER1_PEER_IP)
+        let res = server
+            .post_request_from_ip(test::USER1_PEER_IP)
             .path("/v1/admin/cidrs")
             .body(serde_json::to_string(&contents)?)
             .reply(&filter)
@@ -186,7 +190,8 @@ mod tests {
             parent: Some(test::ROOT_CIDR_ID),
         };
         let filter = crate::routes(server.context());
-        let res = server.post_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server
+            .post_request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/cidrs")
             .body(serde_json::to_string(&contents)?)
             .reply(&filter)
@@ -200,7 +205,8 @@ mod tests {
         };
 
         let filter = crate::routes(server.context());
-        let res = server.post_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server
+            .post_request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/cidrs")
             .body(serde_json::to_string(&contents)?)
             .reply(&filter)
@@ -220,7 +226,8 @@ mod tests {
             parent: Some(test::ROOT_CIDR_ID),
         };
         let filter = crate::routes(server.context());
-        let res = server.post_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server
+            .post_request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/cidrs")
             .body(serde_json::to_string(&contents)?)
             .reply(&filter)
@@ -253,7 +260,8 @@ mod tests {
 
         let filter = crate::routes(server.context());
 
-        let res = server.request_from_ip(test::ADMIN_PEER_IP)
+        let res = server
+            .request_from_ip(test::ADMIN_PEER_IP)
             .method("DELETE")
             .path(&format!("/v1/admin/cidrs/{}", experimental_cidr.id))
             .reply(&filter)
@@ -261,7 +269,8 @@ mod tests {
         // Should fail because child CIDR exists.
         assert_eq!(res.status(), StatusCode::BAD_REQUEST);
 
-        let res = server.request_from_ip(test::ADMIN_PEER_IP)
+        let res = server
+            .request_from_ip(test::ADMIN_PEER_IP)
             .method("DELETE")
             .path(&format!("/v1/admin/cidrs/{}", experimental_subcidr.id))
             .reply(&filter)
@@ -269,7 +278,8 @@ mod tests {
         // Deleting child "leaf" CIDR should fail because peer exists inside it.
         assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
-        let res = server.request_from_ip(test::ADMIN_PEER_IP)
+        let res = server
+            .request_from_ip(test::ADMIN_PEER_IP)
             .method("DELETE")
             .path(&format!("/v1/admin/cidrs/{}", experimental_cidr.id))
             .reply(&filter)
@@ -304,7 +314,8 @@ mod tests {
 
         let filter = crate::routes(server.context());
 
-        let res = server.request_from_ip(test::ADMIN_PEER_IP)
+        let res = server
+            .request_from_ip(test::ADMIN_PEER_IP)
             .method("DELETE")
             .path(&format!("/v1/admin/cidrs/{}", experimental_cidr.id))
             .reply(&filter)

--- a/server/src/api/admin/cidr.rs
+++ b/server/src/api/admin/cidr.rs
@@ -104,7 +104,7 @@ mod tests {
         };
 
         let filter = crate::routes(server.context());
-        let res = test::post_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server.post_request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/cidrs")
             .body(serde_json::to_string(&contents)?)
             .reply(&filter)
@@ -132,7 +132,7 @@ mod tests {
         };
 
         let filter = crate::routes(server.context());
-        let res = test::post_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server.post_request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/cidrs")
             .body(serde_json::to_string(&contents)?)
             .reply(&filter)
@@ -145,7 +145,7 @@ mod tests {
             cidr: test::EXPERIMENTAL_SUBCIDR.parse()?,
             parent: Some(cidr_res.id),
         };
-        let res = test::post_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server.post_request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/cidrs")
             .body(serde_json::to_string(&contents)?)
             .reply(&filter)
@@ -166,7 +166,7 @@ mod tests {
         };
 
         let filter = crate::routes(server.context());
-        let res = test::post_request_from_ip(test::USER1_PEER_IP)
+        let res = server.post_request_from_ip(test::USER1_PEER_IP)
             .path("/v1/admin/cidrs")
             .body(serde_json::to_string(&contents)?)
             .reply(&filter)
@@ -186,7 +186,7 @@ mod tests {
             parent: Some(test::ROOT_CIDR_ID),
         };
         let filter = crate::routes(server.context());
-        let res = test::post_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server.post_request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/cidrs")
             .body(serde_json::to_string(&contents)?)
             .reply(&filter)
@@ -200,7 +200,7 @@ mod tests {
         };
 
         let filter = crate::routes(server.context());
-        let res = test::post_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server.post_request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/cidrs")
             .body(serde_json::to_string(&contents)?)
             .reply(&filter)
@@ -220,7 +220,7 @@ mod tests {
             parent: Some(test::ROOT_CIDR_ID),
         };
         let filter = crate::routes(server.context());
-        let res = test::post_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server.post_request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/cidrs")
             .body(serde_json::to_string(&contents)?)
             .reply(&filter)
@@ -253,7 +253,7 @@ mod tests {
 
         let filter = crate::routes(server.context());
 
-        let res = test::request_from_ip(test::ADMIN_PEER_IP)
+        let res = server.request_from_ip(test::ADMIN_PEER_IP)
             .method("DELETE")
             .path(&format!("/v1/admin/cidrs/{}", experimental_cidr.id))
             .reply(&filter)
@@ -261,7 +261,7 @@ mod tests {
         // Should fail because child CIDR exists.
         assert_eq!(res.status(), StatusCode::BAD_REQUEST);
 
-        let res = test::request_from_ip(test::ADMIN_PEER_IP)
+        let res = server.request_from_ip(test::ADMIN_PEER_IP)
             .method("DELETE")
             .path(&format!("/v1/admin/cidrs/{}", experimental_subcidr.id))
             .reply(&filter)
@@ -269,7 +269,7 @@ mod tests {
         // Deleting child "leaf" CIDR should fail because peer exists inside it.
         assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
-        let res = test::request_from_ip(test::ADMIN_PEER_IP)
+        let res = server.request_from_ip(test::ADMIN_PEER_IP)
             .method("DELETE")
             .path(&format!("/v1/admin/cidrs/{}", experimental_cidr.id))
             .reply(&filter)
@@ -304,7 +304,7 @@ mod tests {
 
         let filter = crate::routes(server.context());
 
-        let res = test::request_from_ip(test::ADMIN_PEER_IP)
+        let res = server.request_from_ip(test::ADMIN_PEER_IP)
             .method("DELETE")
             .path(&format!("/v1/admin/cidrs/{}", experimental_cidr.id))
             .reply(&filter)

--- a/server/src/api/admin/peer.rs
+++ b/server/src/api/admin/peer.rs
@@ -147,7 +147,8 @@ mod tests {
         let peer = test::developer_peer_contents("developer3", "10.80.64.4")?;
 
         let filter = crate::routes(server.context());
-        let res = server.post_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server
+            .post_request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/peers")
             .body(serde_json::to_string(&peer)?)
             .reply(&filter)
@@ -172,7 +173,8 @@ mod tests {
         let peer = test::developer_peer_contents("devel oper", "10.80.64.4")?;
 
         let filter = crate::routes(server.context());
-        let res = server.post_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server
+            .post_request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/peers")
             .body(serde_json::to_string(&peer)?)
             .reply(&filter)
@@ -192,7 +194,8 @@ mod tests {
         let peer = test::developer_peer_contents("developer2", "10.80.64.4")?;
 
         let filter = crate::routes(server.context());
-        let res = server.post_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server
+            .post_request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/peers")
             .body(serde_json::to_string(&peer)?)
             .reply(&filter)
@@ -217,7 +220,8 @@ mod tests {
         let peer = test::developer_peer_contents("developer3", "10.80.64.3")?;
 
         let filter = crate::routes(server.context());
-        let res = server.post_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server
+            .post_request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/peers")
             .body(serde_json::to_string(&peer)?)
             .reply(&filter)
@@ -241,7 +245,8 @@ mod tests {
 
         // Try to add IP outside of the CIDR network.
         let peer = test::developer_peer_contents("developer3", "10.80.65.4")?;
-        let res = server.post_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server
+            .post_request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/peers")
             .body(serde_json::to_string(&peer)?)
             .reply(&filter)
@@ -250,7 +255,8 @@ mod tests {
 
         // Try to use the network address as peer IP.
         let peer = test::developer_peer_contents("developer3", "10.80.64.0")?;
-        let res = server.post_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server
+            .post_request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/peers")
             .body(serde_json::to_string(&peer)?)
             .reply(&filter)
@@ -259,7 +265,8 @@ mod tests {
 
         // Try to use the broadcast address as peer IP.
         let peer = test::developer_peer_contents("developer3", "10.80.64.255")?;
-        let res = server.post_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server
+            .post_request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/peers")
             .body(serde_json::to_string(&peer)?)
             .reply(&filter)
@@ -281,7 +288,8 @@ mod tests {
 
         // Try to create a new developer peer from a user peer.
         let filter = crate::routes(server.context());
-        let res = server.post_request_from_ip(test::USER1_PEER_IP)
+        let res = server
+            .post_request_from_ip(test::USER1_PEER_IP)
             .path("/v1/admin/peers")
             .body(serde_json::to_string(&peer)?)
             .reply(&filter)
@@ -304,7 +312,8 @@ mod tests {
 
         // Try to create a new developer peer from a user peer.
         let filter = crate::routes(server.context());
-        let res = server.put_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server
+            .put_request_from_ip(test::ADMIN_PEER_IP)
             .path(&format!("/v1/admin/peers/{}", test::DEVELOPER1_PEER_ID))
             .body(serde_json::to_string(&change)?)
             .reply(&filter)
@@ -325,7 +334,8 @@ mod tests {
 
         // Try to create a new developer peer from a user peer.
         let filter = crate::routes(server.context());
-        let res = server.put_request_from_ip(test::USER1_PEER_IP)
+        let res = server
+            .put_request_from_ip(test::USER1_PEER_IP)
             .path(&format!("/v1/admin/peers/{}", test::ADMIN_PEER_ID))
             .body(serde_json::to_string(&peer)?)
             .reply(&filter)
@@ -340,7 +350,8 @@ mod tests {
     async fn test_list_all_peers_from_admin() -> Result<()> {
         let server = test::Server::new()?;
         let filter = crate::routes(server.context());
-        let res = server.request_from_ip(test::ADMIN_PEER_IP)
+        let res = server
+            .request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/peers")
             .reply(&filter)
             .await;
@@ -369,7 +380,8 @@ mod tests {
     async fn test_list_all_peers_from_non_admin() -> Result<()> {
         let server = test::Server::new()?;
         let filter = crate::routes(server.context());
-        let res = server.request_from_ip(test::DEVELOPER1_PEER_IP)
+        let res = server
+            .request_from_ip(test::DEVELOPER1_PEER_IP)
             .path("/v1/admin/peers")
             .reply(&filter)
             .await;
@@ -386,7 +398,8 @@ mod tests {
 
         let old_peers = DatabasePeer::list(&server.db().lock())?;
 
-        let res = server.request_from_ip(test::ADMIN_PEER_IP)
+        let res = server
+            .request_from_ip(test::ADMIN_PEER_IP)
             .method("DELETE")
             .path(&format!("/v1/admin/peers/{}", test::USER1_PEER_ID))
             .reply(&filter)
@@ -409,7 +422,8 @@ mod tests {
 
         let old_peers = DatabasePeer::list(&server.db().lock())?;
 
-        let res = server.request_from_ip(test::DEVELOPER1_PEER_IP)
+        let res = server
+            .request_from_ip(test::DEVELOPER1_PEER_IP)
             .method("DELETE")
             .path(&format!("/v1/admin/peers/{}", test::USER1_PEER_ID))
             .reply(&filter)
@@ -429,7 +443,8 @@ mod tests {
         let server = test::Server::new()?;
         let filter = crate::routes(server.context());
 
-        let res = server.request_from_ip(test::ADMIN_PEER_IP)
+        let res = server
+            .request_from_ip(test::ADMIN_PEER_IP)
             .method("DELETE")
             .path(&format!("/v1/admin/peers/{}", test::USER1_PEER_ID + 100))
             .reply(&filter)

--- a/server/src/api/admin/peer.rs
+++ b/server/src/api/admin/peer.rs
@@ -147,7 +147,7 @@ mod tests {
         let peer = test::developer_peer_contents("developer3", "10.80.64.4")?;
 
         let filter = crate::routes(server.context());
-        let res = test::post_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server.post_request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/peers")
             .body(serde_json::to_string(&peer)?)
             .reply(&filter)
@@ -172,7 +172,7 @@ mod tests {
         let peer = test::developer_peer_contents("devel oper", "10.80.64.4")?;
 
         let filter = crate::routes(server.context());
-        let res = test::post_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server.post_request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/peers")
             .body(serde_json::to_string(&peer)?)
             .reply(&filter)
@@ -192,7 +192,7 @@ mod tests {
         let peer = test::developer_peer_contents("developer2", "10.80.64.4")?;
 
         let filter = crate::routes(server.context());
-        let res = test::post_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server.post_request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/peers")
             .body(serde_json::to_string(&peer)?)
             .reply(&filter)
@@ -217,7 +217,7 @@ mod tests {
         let peer = test::developer_peer_contents("developer3", "10.80.64.3")?;
 
         let filter = crate::routes(server.context());
-        let res = test::post_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server.post_request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/peers")
             .body(serde_json::to_string(&peer)?)
             .reply(&filter)
@@ -241,7 +241,7 @@ mod tests {
 
         // Try to add IP outside of the CIDR network.
         let peer = test::developer_peer_contents("developer3", "10.80.65.4")?;
-        let res = test::post_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server.post_request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/peers")
             .body(serde_json::to_string(&peer)?)
             .reply(&filter)
@@ -250,7 +250,7 @@ mod tests {
 
         // Try to use the network address as peer IP.
         let peer = test::developer_peer_contents("developer3", "10.80.64.0")?;
-        let res = test::post_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server.post_request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/peers")
             .body(serde_json::to_string(&peer)?)
             .reply(&filter)
@@ -259,7 +259,7 @@ mod tests {
 
         // Try to use the broadcast address as peer IP.
         let peer = test::developer_peer_contents("developer3", "10.80.64.255")?;
-        let res = test::post_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server.post_request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/peers")
             .body(serde_json::to_string(&peer)?)
             .reply(&filter)
@@ -281,7 +281,7 @@ mod tests {
 
         // Try to create a new developer peer from a user peer.
         let filter = crate::routes(server.context());
-        let res = test::post_request_from_ip(test::USER1_PEER_IP)
+        let res = server.post_request_from_ip(test::USER1_PEER_IP)
             .path("/v1/admin/peers")
             .body(serde_json::to_string(&peer)?)
             .reply(&filter)
@@ -304,7 +304,7 @@ mod tests {
 
         // Try to create a new developer peer from a user peer.
         let filter = crate::routes(server.context());
-        let res = test::put_request_from_ip(test::ADMIN_PEER_IP)
+        let res = server.put_request_from_ip(test::ADMIN_PEER_IP)
             .path(&format!("/v1/admin/peers/{}", test::DEVELOPER1_PEER_ID))
             .body(serde_json::to_string(&change)?)
             .reply(&filter)
@@ -325,7 +325,7 @@ mod tests {
 
         // Try to create a new developer peer from a user peer.
         let filter = crate::routes(server.context());
-        let res = test::put_request_from_ip(test::USER1_PEER_IP)
+        let res = server.put_request_from_ip(test::USER1_PEER_IP)
             .path(&format!("/v1/admin/peers/{}", test::ADMIN_PEER_ID))
             .body(serde_json::to_string(&peer)?)
             .reply(&filter)
@@ -340,7 +340,7 @@ mod tests {
     async fn test_list_all_peers_from_admin() -> Result<()> {
         let server = test::Server::new()?;
         let filter = crate::routes(server.context());
-        let res = test::request_from_ip(test::ADMIN_PEER_IP)
+        let res = server.request_from_ip(test::ADMIN_PEER_IP)
             .path("/v1/admin/peers")
             .reply(&filter)
             .await;
@@ -369,7 +369,7 @@ mod tests {
     async fn test_list_all_peers_from_non_admin() -> Result<()> {
         let server = test::Server::new()?;
         let filter = crate::routes(server.context());
-        let res = test::request_from_ip(test::DEVELOPER1_PEER_IP)
+        let res = server.request_from_ip(test::DEVELOPER1_PEER_IP)
             .path("/v1/admin/peers")
             .reply(&filter)
             .await;
@@ -386,7 +386,7 @@ mod tests {
 
         let old_peers = DatabasePeer::list(&server.db().lock())?;
 
-        let res = test::request_from_ip(test::ADMIN_PEER_IP)
+        let res = server.request_from_ip(test::ADMIN_PEER_IP)
             .method("DELETE")
             .path(&format!("/v1/admin/peers/{}", test::USER1_PEER_ID))
             .reply(&filter)
@@ -409,7 +409,7 @@ mod tests {
 
         let old_peers = DatabasePeer::list(&server.db().lock())?;
 
-        let res = test::request_from_ip(test::DEVELOPER1_PEER_IP)
+        let res = server.request_from_ip(test::DEVELOPER1_PEER_IP)
             .method("DELETE")
             .path(&format!("/v1/admin/peers/{}", test::USER1_PEER_ID))
             .reply(&filter)
@@ -429,7 +429,7 @@ mod tests {
         let server = test::Server::new()?;
         let filter = crate::routes(server.context());
 
-        let res = test::request_from_ip(test::ADMIN_PEER_IP)
+        let res = server.request_from_ip(test::ADMIN_PEER_IP)
             .method("DELETE")
             .path(&format!("/v1/admin/peers/{}", test::USER1_PEER_ID + 100))
             .reply(&filter)

--- a/server/src/api/user.rs
+++ b/server/src/api/user.rs
@@ -171,7 +171,8 @@ mod tests {
     async fn test_get_state_from_developer1() -> Result<()> {
         let server = test::Server::new()?;
         let filter = crate::routes(server.context());
-        let res = server.request_from_ip(test::DEVELOPER1_PEER_IP)
+        let res = server
+            .request_from_ip(test::DEVELOPER1_PEER_IP)
             .path("/v1/user/state")
             .reply(&filter)
             .await;
@@ -195,7 +196,8 @@ mod tests {
         let server = test::Server::new()?;
         let filter = crate::routes(server.context());
         assert_eq!(
-            server.put_request_from_ip(test::DEVELOPER1_PEER_IP)
+            server
+                .put_request_from_ip(test::DEVELOPER1_PEER_IP)
                 .path("/v1/user/endpoint")
                 .body(serde_json::to_string(&EndpointContents::Set(
                     "1.1.1.1:51820".parse()?
@@ -208,7 +210,8 @@ mod tests {
 
         println!("{}", serde_json::to_string(&EndpointContents::Unset)?);
         assert_eq!(
-            server.put_request_from_ip(test::DEVELOPER1_PEER_IP)
+            server
+                .put_request_from_ip(test::DEVELOPER1_PEER_IP)
                 .path("/v1/user/endpoint")
                 .body(serde_json::to_string(&EndpointContents::Unset)?)
                 .reply(&filter)
@@ -218,7 +221,8 @@ mod tests {
         );
 
         assert_eq!(
-            server.put_request_from_ip(test::DEVELOPER1_PEER_IP)
+            server
+                .put_request_from_ip(test::DEVELOPER1_PEER_IP)
                 .path("/v1/user/endpoint")
                 .body("endpoint=blah")
                 .reply(&filter)
@@ -236,7 +240,8 @@ mod tests {
         let filter = crate::routes(server.context());
 
         // Request comes from an unknown IP.
-        let res = server.request_from_ip("10.80.80.80")
+        let res = server
+            .request_from_ip("10.80.80.80")
             .path("/v1/user/state")
             .reply(&filter)
             .await;
@@ -296,7 +301,8 @@ mod tests {
         }
 
         for ip in &[test::DEVELOPER1_PEER_IP, test::EXPERIMENT_SUBCIDR_PEER_IP] {
-            let res = server.request_from_ip(ip)
+            let res = server
+                .request_from_ip(ip)
                 .path("/v1/user/state")
                 .reply(&filter)
                 .await;
@@ -344,7 +350,8 @@ mod tests {
         let filter = crate::routes(server.context());
 
         // Step 1: Ensure that before redeeming, other endpoints aren't yet accessible.
-        let res = server.request_from_ip(test::EXPERIMENT_SUBCIDR_PEER_IP)
+        let res = server
+            .request_from_ip(test::EXPERIMENT_SUBCIDR_PEER_IP)
             .path("/v1/user/state")
             .reply(&filter)
             .await;
@@ -354,7 +361,8 @@ mod tests {
         let body = RedeemContents {
             public_key: "YBVIgpfLbi/knrMCTEb0L6eVy0daiZnJJQkxBK9s+2I=".into(),
         };
-        let res = server.post_request_from_ip(test::EXPERIMENT_SUBCIDR_PEER_IP)
+        let res = server
+            .post_request_from_ip(test::EXPERIMENT_SUBCIDR_PEER_IP)
             .path("/v1/user/redeem")
             .body(serde_json::to_string(&body)?)
             .reply(&filter)
@@ -362,7 +370,8 @@ mod tests {
         assert!(res.status().is_success());
 
         // Step 3: Ensure that a second attempt at redemption DOESN'T work.
-        let res = server.post_request_from_ip(test::EXPERIMENT_SUBCIDR_PEER_IP)
+        let res = server
+            .post_request_from_ip(test::EXPERIMENT_SUBCIDR_PEER_IP)
             .path("/v1/user/redeem")
             .body(serde_json::to_string(&body)?)
             .reply(&filter)
@@ -370,7 +379,8 @@ mod tests {
         assert!(res.status().is_client_error());
 
         // Step 3: Ensure that after redemption, fetching state works.
-        let res = server.request_from_ip(test::EXPERIMENT_SUBCIDR_PEER_IP)
+        let res = server
+            .request_from_ip(test::EXPERIMENT_SUBCIDR_PEER_IP)
             .path("/v1/user/state")
             .reply(&filter)
             .await;

--- a/server/src/api/user.rs
+++ b/server/src/api/user.rs
@@ -171,7 +171,7 @@ mod tests {
     async fn test_get_state_from_developer1() -> Result<()> {
         let server = test::Server::new()?;
         let filter = crate::routes(server.context());
-        let res = test::request_from_ip(test::DEVELOPER1_PEER_IP)
+        let res = server.request_from_ip(test::DEVELOPER1_PEER_IP)
             .path("/v1/user/state")
             .reply(&filter)
             .await;
@@ -195,7 +195,7 @@ mod tests {
         let server = test::Server::new()?;
         let filter = crate::routes(server.context());
         assert_eq!(
-            test::put_request_from_ip(test::DEVELOPER1_PEER_IP)
+            server.put_request_from_ip(test::DEVELOPER1_PEER_IP)
                 .path("/v1/user/endpoint")
                 .body(serde_json::to_string(&EndpointContents::Set(
                     "1.1.1.1:51820".parse()?
@@ -208,7 +208,7 @@ mod tests {
 
         println!("{}", serde_json::to_string(&EndpointContents::Unset)?);
         assert_eq!(
-            test::put_request_from_ip(test::DEVELOPER1_PEER_IP)
+            server.put_request_from_ip(test::DEVELOPER1_PEER_IP)
                 .path("/v1/user/endpoint")
                 .body(serde_json::to_string(&EndpointContents::Unset)?)
                 .reply(&filter)
@@ -218,7 +218,7 @@ mod tests {
         );
 
         assert_eq!(
-            test::put_request_from_ip(test::DEVELOPER1_PEER_IP)
+            server.put_request_from_ip(test::DEVELOPER1_PEER_IP)
                 .path("/v1/user/endpoint")
                 .body("endpoint=blah")
                 .reply(&filter)
@@ -236,7 +236,7 @@ mod tests {
         let filter = crate::routes(server.context());
 
         // Request comes from an unknown IP.
-        let res = test::request_from_ip("10.80.80.80")
+        let res = server.request_from_ip("10.80.80.80")
             .path("/v1/user/state")
             .reply(&filter)
             .await;
@@ -296,7 +296,7 @@ mod tests {
         }
 
         for ip in &[test::DEVELOPER1_PEER_IP, test::EXPERIMENT_SUBCIDR_PEER_IP] {
-            let res = test::request_from_ip(ip)
+            let res = server.request_from_ip(ip)
                 .path("/v1/user/state")
                 .reply(&filter)
                 .await;
@@ -344,7 +344,7 @@ mod tests {
         let filter = crate::routes(server.context());
 
         // Step 1: Ensure that before redeeming, other endpoints aren't yet accessible.
-        let res = test::request_from_ip(test::EXPERIMENT_SUBCIDR_PEER_IP)
+        let res = server.request_from_ip(test::EXPERIMENT_SUBCIDR_PEER_IP)
             .path("/v1/user/state")
             .reply(&filter)
             .await;
@@ -354,7 +354,7 @@ mod tests {
         let body = RedeemContents {
             public_key: "YBVIgpfLbi/knrMCTEb0L6eVy0daiZnJJQkxBK9s+2I=".into(),
         };
-        let res = test::post_request_from_ip(test::EXPERIMENT_SUBCIDR_PEER_IP)
+        let res = server.post_request_from_ip(test::EXPERIMENT_SUBCIDR_PEER_IP)
             .path("/v1/user/redeem")
             .body(serde_json::to_string(&body)?)
             .reply(&filter)
@@ -362,7 +362,7 @@ mod tests {
         assert!(res.status().is_success());
 
         // Step 3: Ensure that a second attempt at redemption DOESN'T work.
-        let res = test::post_request_from_ip(test::EXPERIMENT_SUBCIDR_PEER_IP)
+        let res = server.post_request_from_ip(test::EXPERIMENT_SUBCIDR_PEER_IP)
             .path("/v1/user/redeem")
             .body(serde_json::to_string(&body)?)
             .reply(&filter)
@@ -370,7 +370,7 @@ mod tests {
         assert!(res.status().is_client_error());
 
         // Step 3: Ensure that after redemption, fetching state works.
-        let res = test::request_from_ip(test::EXPERIMENT_SUBCIDR_PEER_IP)
+        let res = server.request_from_ip(test::EXPERIMENT_SUBCIDR_PEER_IP)
             .path("/v1/user/state")
             .reply(&filter)
             .await;

--- a/shared/src/interface_config.rs
+++ b/shared/src/interface_config.rs
@@ -11,7 +11,7 @@ use std::{
 };
 use wgctrl::InterfaceName;
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Clone, Deserialize, Serialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct InterfaceConfig {
     /// The information to bring up the interface.
@@ -21,7 +21,7 @@ pub struct InterfaceConfig {
     pub server: ServerInfo,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Clone, Deserialize, Serialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct InterfaceInfo {
     /// The interface name (i.e. "tonari")
@@ -38,7 +38,7 @@ pub struct InterfaceInfo {
     pub listen_port: Option<u16>,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Clone, Deserialize, Serialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct ServerInfo {
     /// The server's WireGuard public key

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -27,7 +27,8 @@ lazy_static! {
     pub static ref REDEEM_TRANSITION_WAIT: Duration = Duration::from_secs(5);
 }
 
-pub static PERSISTENT_KEEPALIVE_INTERVAL_SECS: u16 = 25;
+pub const PERSISTENT_KEEPALIVE_INTERVAL_SECS: u16 = 25;
+pub const INNERNET_PUBKEY_HEADER: &str = "X-Innernet-Server-Key";
 
 pub type Error = Box<dyn std::error::Error>;
 

--- a/wgctrl-rs/src/backends/userspace.rs
+++ b/wgctrl-rs/src/backends/userspace.rs
@@ -366,7 +366,7 @@ pub fn apply(builder: DeviceConfigBuilder, iface: &InterfaceName) -> io::Result<
 /// `Key`s, especially ones created from external data.
 #[cfg(not(target_os = "linux"))]
 #[derive(PartialEq, Eq, Clone)]
-pub struct Key([u8; 32]);
+pub struct Key(pub [u8; 32]);
 
 #[cfg(not(target_os = "linux"))]
 impl Key {


### PR DESCRIPTION
Right now, any application on a peer's computer can make innernet API requests to the server on behalf of that user, which is bad.

This PR is a *temporary* simple interim solution until a more refined solution is worked out.

## Mechanism

The server will require, on all requests, an `X-Innernet-Server-Key` header, the value being the public key of the server.

This way, the requester is *at least* required to be able to query the WireGuard interface, read the config file, or know the server's public key some other way which we assume for now is not being actively broadcast to attackers with the motivation to in turn create a targeted attack.

## Downsides

Public keys are obviously not intended to be used as "secret" data, and the CSRF security of innernet should not be linked to whether the innernet network's server public key is widely known or not.

All clients will need to upgrade their version of innernet once the server is upgraded.