### PR TITLE
{client,server}: allow peer/cidr creation with CLI arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,6 +1165,7 @@ dependencies = [
  "lazy_static",
  "regex",
  "serde",
+ "structopt",
  "toml",
  "ureq",
  "wgctrl",

--- a/client/src/util.rs
+++ b/client/src/util.rs
@@ -2,8 +2,8 @@ use crate::{ClientError, Error};
 use colored::*;
 use serde::{de::DeserializeOwned, Serialize};
 use shared::{interface_config::ServerInfo, INNERNET_PUBKEY_HEADER};
-use ureq::{Agent, AgentBuilder};
 use std::time::Duration;
+use ureq::{Agent, AgentBuilder};
 
 pub fn human_duration(duration: Duration) -> String {
     match duration.as_secs() {
@@ -81,11 +81,13 @@ impl<'a> Api<'a> {
         endpoint: &str,
         form: Option<S>,
     ) -> Result<T, Error> {
-        let request = self.agent.request(
-            verb,
-            &format!("http://{}/v1{}", self.server.internal_endpoint, endpoint),
-        )
-        .set(INNERNET_PUBKEY_HEADER, &self.server.public_key);
+        let request = self
+            .agent
+            .request(
+                verb,
+                &format!("http://{}/v1{}", self.server.internal_endpoint, endpoint),
+            )
+            .set(INNERNET_PUBKEY_HEADER, &self.server.public_key);
 
         let response = if let Some(form) = form {
             request.send_json(serde_json::to_value(form)?)?

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -14,6 +14,7 @@ ipnetwork = { git = "https://github.com/mcginty/ipnetwork" } # pending https://g
 lazy_static = "1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
+structopt = "0.3"
 toml = "0.5"
 ureq = { version = "2", default-features = false }
 wgctrl = { path = "../wgctrl-rs" }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -40,7 +40,11 @@ pub fn ensure_dirs_exist(dirs: &[&Path]) -> Result<(), Error> {
             _ => {
                 let target_file = File::open(dir).with_path(dir)?;
                 if chmod(&target_file, 0o700)? {
-                    println!("{} updated permissions for {} to 0700.", "[!]".yellow(), dir.display());
+                    println!(
+                        "{} updated permissions for {} to 0700.",
+                        "[!]".yellow(),
+                        dir.display()
+                    );
                 }
             },
         }
@@ -52,16 +56,16 @@ pub fn ensure_dirs_exist(dirs: &[&Path]) -> Result<(), Error> {
 /// permissions had to be changed, `Ok(false)` if permissions were already
 /// correct.
 pub fn chmod(file: &File, new_mode: u32) -> Result<bool, Error> {
-        let metadata = file.metadata()?;
-        let mut permissions = metadata.permissions();
-        let mode  = permissions.mode() & 0o777;
-        let updated = if mode != new_mode {
-            permissions.set_mode(new_mode);
-            file.set_permissions(permissions)?;
-            true
-        } else {
-            false
-        };
+    let metadata = file.metadata()?;
+    let mut permissions = metadata.permissions();
+    let mode = permissions.mode() & 0o777;
+    let updated = if mode != new_mode {
+        permissions.set_mode(new_mode);
+        file.set_permissions(permissions)?;
+        true
+    } else {
+        false
+    };
 
-        Ok(updated)
+    Ok(updated)
 }

--- a/shared/src/types.rs
+++ b/shared/src/types.rs
@@ -1,5 +1,5 @@
-use ipnetwork::IpNetwork;
 use crate::prompts::hostname_validator;
+use ipnetwork::IpNetwork;
 use serde::{Deserialize, Serialize};
 use std::{
     fmt::{Display, Formatter},
@@ -8,6 +8,7 @@ use std::{
     path::Path,
     str::FromStr,
 };
+use structopt::StructOpt;
 use wgctrl::{InterfaceName, InvalidInterfaceName, Key, PeerConfig, PeerConfigBuilder};
 
 #[derive(Debug, Clone)]
@@ -163,6 +164,51 @@ impl<'a> CidrTree<'a> {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct RedeemContents {
     pub public_key: String,
+}
+
+#[derive(Debug, Clone, PartialEq, StructOpt)]
+pub struct AddPeerContents {
+    /// Name of new peer
+    #[structopt(long)]
+    pub name: Option<String>,
+
+    /// Specify desired IP of new peer (within parent CIDR)
+    #[structopt(long, conflicts_with = "auto-ip")]
+    pub ip: Option<IpAddr>,
+
+    /// Auto-assign the peer the first available IP within the CIDR
+    #[structopt(long = "auto-ip")]
+    pub auto_ip: bool,
+
+    /// Name of CIDR to add new peer under
+    #[structopt(long)]
+    pub cidr: Option<String>,
+
+    /// Make new peer an admin
+    #[structopt(long)]
+    pub admin: Option<bool>,
+
+    /// Force confirmation
+    #[structopt(short, long)]
+    pub force: bool,
+
+    #[structopt(long)]
+    pub save_config: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, StructOpt)]
+pub struct AddCidrContents {
+    #[structopt(long)]
+    pub name: Option<String>,
+
+    #[structopt(long)]
+    pub cidr: Option<IpNetwork>,
+
+    #[structopt(long)]
+    pub parent: Option<String>,
+
+    #[structopt(short, long)]
+    pub force: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]

--- a/wgctrl-rs/src/device.rs
+++ b/wgctrl-rs/src/device.rs
@@ -309,11 +309,14 @@ mod tests {
 
     #[test]
     fn test_interface_names() {
-        assert_eq!("wg-01".parse::<InterfaceName>().unwrap().as_str_lossy(), "wg-01");
+        assert_eq!(
+            "wg-01".parse::<InterfaceName>().unwrap().as_str_lossy(),
+            "wg-01"
+        );
         assert!("longer-nul\0".parse::<InterfaceName>().is_err());
 
         let invalid_names = &[
-            ("", InvalidInterfaceName::Empty),   // Empty Rust string
+            ("", InvalidInterfaceName::Empty),          // Empty Rust string
             ("\0", InvalidInterfaceName::InvalidChars), // Empty C string
             ("ifname\0nul", InvalidInterfaceName::InvalidChars), // Contains interior NUL
             ("if name", InvalidInterfaceName::InvalidChars), // Contains a space


### PR DESCRIPTION
Addresses #20.

## Add a peer
```bash
innernet add-peer --auto-ip \
  --cidr "humans" \
  --name "mcginty" \
  --admin false \
  --save-config "mcginty.toml" \
  --force \
  tonari
```

## Add a CIDR
```bash
innernet add-cidr \
  --name "humans" \
  --cidr "10.42.5.0/24" \
  --parent "tonari" \
  --force \
  tonari
```