### PR TITLE
Allow hostnames in endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,6 +1138,7 @@ dependencies = [
  "tokio",
  "toml",
  "ureq",
+ "url",
  "warp",
  "wgctrl",
 ]
@@ -1169,6 +1170,7 @@ dependencies = [
  "structopt",
  "toml",
  "ureq",
+ "url",
  "wgctrl",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,6 +1524,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,7 +1524,6 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
- "serde",
 ]
 
 [[package]]

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -283,6 +283,7 @@ fn redeem_invite(
     target_conf: PathBuf,
 ) -> Result<(), Error> {
     println!("{} bringing up the interface.", "[*]".dimmed());
+    let resolved_endpoint = config.server.external_endpoint.resolve()?;
     wg::up(
         &iface,
         &config.interface.private_key,
@@ -291,7 +292,7 @@ fn redeem_invite(
         Some((
             &config.server.public_key,
             config.server.internal_endpoint.ip(),
-            config.server.external_endpoint,
+            resolved_endpoint,
         )),
     )?;
 
@@ -369,6 +370,7 @@ fn fetch(
         }
 
         println!("{} bringing up the interface.", "[*]".dimmed());
+        let resolved_endpoint = config.server.external_endpoint.resolve()?;
         wg::up(
             interface,
             &config.interface.private_key,
@@ -377,7 +379,7 @@ fn fetch(
             Some((
                 &config.server.public_key,
                 config.server.internal_endpoint.ip(),
-                config.server.external_endpoint,
+                resolved_endpoint,
             )),
         )?
     }
@@ -821,7 +823,7 @@ fn print_peer(our_peer: &Peer, peer: &PeerInfo, short: bool) -> Result<(), Error
             &our_peer.public_key[..10].yellow()
         );
         println!("  {}: {}", "ip".bold(), our_peer.ip);
-        if let Some(endpoint) = our_peer.endpoint {
+        if let Some(ref endpoint) = our_peer.endpoint {
             println!("  {}: {}", "endpoint".bold(), endpoint);
         }
         if let Some(last_handshake) = peer.stats.last_handshake_time {

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -34,6 +34,7 @@ subtle = "2"
 structopt = "0.3"
 thiserror = "1"
 ureq = { version = "2", default-features = false }
+url = "2"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 toml = "0.5"
 warp = { git = "https://github.com/tonarino/warp", default-features = false } # pending https://github.com/seanmonstar/warp/issues/830

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -11,7 +11,7 @@ pub fn inject_endpoints(session: &Session, peers: &mut Vec<Peer>) {
     for mut peer in peers {
         if peer.contents.endpoint.is_none() {
             if let Some(endpoint) = session.context.endpoints.get(&peer.public_key) {
-                peer.contents.endpoint = Some(endpoint.to_owned());
+                peer.contents.endpoint = Some(endpoint.to_owned().into());
             }
         }
     }

--- a/server/src/api/user.rs
+++ b/server/src/api/user.rs
@@ -200,7 +200,7 @@ mod tests {
                 .put_request_from_ip(test::DEVELOPER1_PEER_IP)
                 .path("/v1/user/endpoint")
                 .body(serde_json::to_string(&EndpointContents::Set(
-                    "1.1.1.1:51820".parse()?
+                    "1.1.1.1:51820".parse().unwrap()
                 ))?)
                 .reply(&filter)
                 .await

--- a/server/src/db/peer.rs
+++ b/server/src/db/peer.rs
@@ -95,7 +95,7 @@ impl DatabasePeer {
                 ip.to_string(),
                 cidr_id,
                 &public_key,
-                endpoint.map(|endpoint| endpoint.to_string()),
+                endpoint.as_ref().map(|endpoint| endpoint.to_string()),
                 is_admin,
                 is_disabled,
                 is_redeemed,
@@ -138,7 +138,7 @@ impl DatabasePeer {
             WHERE id = ?5",
             params![
                 new_contents.name,
-                new_contents.endpoint.map(|endpoint| endpoint.to_string()),
+                new_contents.endpoint.as_ref().map(|endpoint| endpoint.to_string()),
                 new_contents.is_admin,
                 new_contents.is_disabled,
                 self.id,

--- a/server/src/db/peer.rs
+++ b/server/src/db/peer.rs
@@ -138,7 +138,10 @@ impl DatabasePeer {
             WHERE id = ?5",
             params![
                 new_contents.name,
-                new_contents.endpoint.as_ref().map(|endpoint| endpoint.to_string()),
+                new_contents
+                    .endpoint
+                    .as_ref()
+                    .map(|endpoint| endpoint.to_string()),
                 new_contents.is_admin,
                 new_contents.is_disabled,
                 self.id,

--- a/server/src/initialize.rs
+++ b/server/src/initialize.rs
@@ -5,7 +5,7 @@ use indoc::printdoc;
 use rusqlite::{params, Connection};
 use shared::{
     prompts::{self, hostname_validator},
-    CidrContents, PeerContents, PERSISTENT_KEEPALIVE_INTERVAL_SECS,
+    Endpoint, CidrContents, PeerContents, PERSISTENT_KEEPALIVE_INTERVAL_SECS,
 };
 use wgctrl::KeyPair;
 
@@ -32,7 +32,7 @@ pub struct InitializeOpts {
 
     /// This server's external endpoint (ex: 100.100.100.100:51820)
     #[structopt(long, conflicts_with = "auto-external-endpoint")]
-    pub external_endpoint: Option<SocketAddr>,
+    pub external_endpoint: Option<Endpoint>,
 
     /// Auto-resolve external endpoint
     #[structopt(long = "auto-external-endpoint")]
@@ -49,7 +49,7 @@ struct DbInitData {
     server_cidr: IpNetwork,
     our_ip: IpAddr,
     public_key_base64: String,
-    endpoint: SocketAddr,
+    endpoint: Endpoint,
 }
 
 fn populate_database(conn: &Connection, db_init_data: DbInitData) -> Result<(), Error> {
@@ -126,7 +126,7 @@ pub fn init_wizard(conf: &ServerConfig, opts: InitializeOpts) -> Result<(), Erro
     // This probably won't error because of the `hostname_validator` regex.
     let name = name.parse()?;
 
-    let endpoint: SocketAddr = if let Some(endpoint) = opts.external_endpoint {
+    let endpoint: Endpoint = if let Some(endpoint) = opts.external_endpoint {
         endpoint.clone()
     } else {
         let external_ip: Option<IpAddr> = ureq::get("http://4.icanhazip.com")
@@ -139,7 +139,7 @@ pub fn init_wizard(conf: &ServerConfig, opts: InitializeOpts) -> Result<(), Erro
 
         if opts.auto_external_endpoint {
             let ip = external_ip.ok_or("couldn't get external IP")?;
-            (ip, 51820).into()
+            SocketAddr::new(ip, 51820).into()
         } else {
             prompts::ask_endpoint(external_ip)?
         }

--- a/server/src/initialize.rs
+++ b/server/src/initialize.rs
@@ -5,7 +5,7 @@ use indoc::printdoc;
 use rusqlite::{params, Connection};
 use shared::{
     prompts::{self, hostname_validator},
-    Endpoint, CidrContents, PeerContents, PERSISTENT_KEEPALIVE_INTERVAL_SECS,
+    CidrContents, Endpoint, PeerContents, PERSISTENT_KEEPALIVE_INTERVAL_SECS,
 };
 use wgctrl::KeyPair;
 

--- a/server/src/test.rs
+++ b/server/src/test.rs
@@ -69,7 +69,7 @@ impl Server {
         let opts = InitializeOpts {
             network_name: Some(interface.clone()),
             network_cidr: Some(ROOT_CIDR.parse()?),
-            external_endpoint: Some("155.155.155.155:54321".parse()?),
+            external_endpoint: Some("155.155.155.155:54321".parse().unwrap()),
             listen_port: Some(54321),
             auto_external_endpoint: false,
         };

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -17,4 +17,5 @@ serde = { version = "1", features = ["derive"] }
 structopt = "0.3"
 toml = "0.5"
 ureq = { version = "2", default-features = false }
+url = "2"
 wgctrl = { path = "../wgctrl-rs" }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -17,5 +17,5 @@ serde = { version = "1", features = ["derive"] }
 structopt = "0.3"
 toml = "0.5"
 ureq = { version = "2", default-features = false }
-url = "2"
+url = { version = "2", features = ["serde"] }
 wgctrl = { path = "../wgctrl-rs" }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -17,5 +17,5 @@ serde = { version = "1", features = ["derive"] }
 structopt = "0.3"
 toml = "0.5"
 ureq = { version = "2", default-features = false }
-url = { version = "2", features = ["serde"] }
+url = "2"
 wgctrl = { path = "../wgctrl-rs" }

--- a/shared/src/interface_config.rs
+++ b/shared/src/interface_config.rs
@@ -1,4 +1,4 @@
-use crate::{ensure_dirs_exist, Error, IoErrorContext, CLIENT_CONFIG_PATH};
+use crate::{CLIENT_CONFIG_PATH, Endpoint, Error, IoErrorContext, ensure_dirs_exist};
 use colored::*;
 use indoc::writedoc;
 use ipnetwork::IpNetwork;
@@ -46,7 +46,7 @@ pub struct ServerInfo {
     pub public_key: String,
 
     /// The external internet endpoint to reach the server.
-    pub external_endpoint: SocketAddr,
+    pub external_endpoint: Endpoint,
 
     /// An internal endpoint in the WireGuard network that hosts the coordination API.
     pub internal_endpoint: SocketAddr,

--- a/shared/src/interface_config.rs
+++ b/shared/src/interface_config.rs
@@ -1,4 +1,4 @@
-use crate::{CLIENT_CONFIG_PATH, Endpoint, Error, IoErrorContext, ensure_dirs_exist};
+use crate::{ensure_dirs_exist, Endpoint, Error, IoErrorContext, CLIENT_CONFIG_PATH};
 use colored::*;
 use indoc::writedoc;
 use ipnetwork::IpNetwork;

--- a/shared/src/prompts.rs
+++ b/shared/src/prompts.rs
@@ -1,4 +1,8 @@
-use crate::{AddCidrOpts, AddPeerOpts, Association, Cidr, CidrContents, CidrTree, Endpoint, Error, PERSISTENT_KEEPALIVE_INTERVAL_SECS, Peer, PeerContents, interface_config::{InterfaceConfig, InterfaceInfo, ServerInfo}};
+use crate::{
+    interface_config::{InterfaceConfig, InterfaceInfo, ServerInfo},
+    AddCidrOpts, AddPeerOpts, Association, Cidr, CidrContents, CidrTree, Endpoint, Error, Peer,
+    PeerContents, PERSISTENT_KEEPALIVE_INTERVAL_SECS,
+};
 use colored::*;
 use dialoguer::{theme::ColorfulTheme, Confirm, Input, Select};
 use ipnetwork::IpNetwork;
@@ -376,7 +380,7 @@ pub fn ask_endpoint(external_ip: Option<IpAddr>) -> Result<Endpoint, Error> {
 
     let mut endpoint_builder = Input::with_theme(&*THEME);
     if let Some(ip) = external_ip {
-        endpoint_builder.default(format!("{}:{}", ip, 51820).parse().unwrap());
+        endpoint_builder.default(SocketAddr::new(ip, 51820).into());
     } else {
         println!("failed to get external IP.");
     }

--- a/shared/src/types.rs
+++ b/shared/src/types.rs
@@ -393,11 +393,7 @@ impl<'a> From<&'a Peer> for PeerConfigBuilder {
             builder
         };
 
-        let resolved = peer
-            .endpoint
-            .as_ref()
-            .map(|e| e.resolve().ok())
-            .flatten();
+        let resolved = peer.endpoint.as_ref().map(|e| e.resolve().ok()).flatten();
 
         if let Some(endpoint) = resolved {
             builder.set_endpoint(endpoint)

--- a/shared/src/types.rs
+++ b/shared/src/types.rs
@@ -9,6 +9,7 @@ use std::{
     str::FromStr,
 };
 use structopt::StructOpt;
+use url::Host;
 use wgctrl::{InterfaceName, InvalidInterfaceName, Key, PeerConfig, PeerConfigBuilder};
 
 #[derive(Debug, Clone)]
@@ -34,6 +35,27 @@ impl Deref for Interface {
 
     fn deref(&self) -> &Self::Target {
         &self.name
+    }
+}
+
+/// An external endpoint that supports both IP and domain name hosts.
+struct Endpoint {
+    host: Host,
+    port: u16,
+}
+
+impl FromStr for Endpoint {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.rsplitn(2, ':').collect::<Vec<&str>>().as_slice() {
+            [port, host] => {
+                let port = port.parse().map_err(|_| "couldn't parse port")?;
+                let host = Host::parse(host).map_err(|_| "couldn't parse host")?;
+                Ok(Endpoint { host, port })
+            },
+            _ => Err("couldn't parse in form of 'host:port'"),
+        }
     }
 }
 

--- a/shared/src/types.rs
+++ b/shared/src/types.rs
@@ -347,8 +347,8 @@ impl Peer {
         assert_eq!(self.public_key, peer.public_key.to_base64());
 
         let endpoint_diff = if let Some(ref endpoint) = self.endpoint {
-            match (endpoint.resolve(), peer.endpoint) {
-                (Ok(resolved), Some(peer_endpoint)) if resolved != peer_endpoint => Some(resolved),
+            match endpoint.resolve() {
+                Ok(resolved) if Some(resolved) != peer.endpoint => Some(resolved),
                 _ => None,
             }
         } else {


### PR DESCRIPTION
This draft creates an `Endpoint` type that wraps [`url::Host`](https://docs.rs/url/2.2.1/url/enum.Host.html) to avoid correctness issues with hostname parsing.

Resolution uses the `ToSocketAddrs` trait in `std`, and only uses the first result.

Fixes #18