### PR TITLE
adapt hostfile crate for Windows

### DIFF
--- a/hostsfile/src/lib.rs
+++ b/hostsfile/src/lib.rs
@@ -124,7 +124,7 @@ impl HostsBuilder {
                 // the location depends on the environment variable %WinDir%.
                 format!(
                     "{}\\System32\\Drivers\\Etc\\hosts",
-                    std::env::var("WinDir").expect("missing environment variable %WinDir%")
+                    std::env::var("WinDir")?
                 ),
             )
         } else {


### PR DESCRIPTION
Windows has some peculiarities for example it only allows one hostname per line and the file's location depends on an environment variable. Although in most cases just using `C:\Windows\` for `%WinDir%` would probably work, it is cleaner to use the documented path.

Note that editing the hosts file on Windows will require running with elevated privileges ("Run as Administrator") and in some cases also antivirus tools may block access to the file. (This is not currently handled specially - when I tried it, the error was the same for missing privileges, and for antivirus blocking access.)

This is a step towards #19.