### PR TITLE
adds ability to delete cidrs

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -4,9 +4,9 @@ use hostsfile::HostsBuilder;
 use indoc::printdoc;
 use shared::{
     interface_config::InterfaceConfig, prompts, AddAssociationOpts, AddCidrOpts, AddPeerOpts,
-    Association, AssociationContents, Cidr, CidrTree, EndpointContents, InstallOpts, Interface,
-    IoErrorContext, NetworkOpt, Peer, RedeemContents, State, CLIENT_CONFIG_DIR,
-    REDEEM_TRANSITION_WAIT,
+    Association, AssociationContents, Cidr, CidrTree, DeleteCidrOpts, EndpointContents,
+    InstallOpts, Interface, IoErrorContext, NetworkOpt, Peer, RedeemContents, State,
+    CLIENT_CONFIG_DIR, REDEEM_TRANSITION_WAIT,
 };
 use std::{
     fmt,
@@ -143,6 +143,14 @@ enum Command {
 
         #[structopt(flatten)]
         opts: AddCidrOpts,
+    },
+
+    /// Delete a CIDR.
+    DeleteCidr {
+        interface: Interface,
+
+        #[structopt(flatten)]
+        opts: DeleteCidrOpts,
     },
 
     /// Disable an enabled peer.
@@ -563,6 +571,23 @@ fn add_cidr(interface: &InterfaceName, opts: AddCidrOpts) -> Result<(), Error> {
     Ok(())
 }
 
+fn delete_cidr(interface: &InterfaceName, opts: DeleteCidrOpts) -> Result<(), Error> {
+    let InterfaceConfig { server, .. } = InterfaceConfig::from_interface(interface)?;
+    println!("Fetching eligible CIDRs");
+    let api = Api::new(&server);
+    let cidrs: Vec<Cidr> = api.http("GET", "/admin/cidrs")?;
+    let peers: Vec<Peer> = api.http("GET", "/admin/peers")?;
+
+    let cidr_id = prompts::delete_cidr(&cidrs, &peers, &opts)?;
+
+    println!("Deleting CIDR...");
+    let _ = api.http("DELETE", &*format!("/admin/cidrs/{}", cidr_id))?;
+
+    println!("CIDR deleted.");
+
+    Ok(())
+}
+
 fn add_peer(interface: &InterfaceName, opts: AddPeerOpts) -> Result<(), Error> {
     let InterfaceConfig { server, .. } = InterfaceConfig::from_interface(interface)?;
     let api = Api::new(&server);
@@ -962,6 +987,7 @@ fn run(opt: Opts) -> Result<(), Error> {
         Command::Uninstall { interface } => uninstall(&interface, opt.network)?,
         Command::AddPeer { interface, opts } => add_peer(&interface, opts)?,
         Command::AddCidr { interface, opts } => add_cidr(&interface, opts)?,
+        Command::DeleteCidr { interface, opts } => delete_cidr(&interface, opts)?,
         Command::DisablePeer { interface } => enable_or_disable_peer(&interface, false)?,
         Command::EnablePeer { interface } => enable_or_disable_peer(&interface, true)?,
         Command::AddAssociation { interface, opts } => add_association(&interface, opts)?,

--- a/shared/src/prompts.rs
+++ b/shared/src/prompts.rs
@@ -74,7 +74,7 @@ pub fn delete_cidr(cidrs: &[Cidr], peers: &[Peer], request: &DeleteCidrOpts) -> 
         cidrs
             .iter()
             .find(|cidr| &cidr.name == name)
-            .ok_or_else(|| format!("CIDR {} does not exist", name))?
+            .ok_or_else(|| format!("CIDR {} doesn't exist or isn't eligible for deletion", name))?
     } else {
         let cidr_index = Select::with_theme(&*THEME)
             .with_prompt("Delete CIDR")

--- a/shared/src/prompts.rs
+++ b/shared/src/prompts.rs
@@ -63,7 +63,6 @@ pub fn delete_cidr(cidrs: &[Cidr], peers: &[Peer], request: &DeleteCidrOpts) -> 
     let eligible_cidrs: Vec<_> = cidrs
         .iter()
         .filter(|cidr| {
-            cidr.name != "innernet-server" &&
             !peers.iter().any(|peer| peer.contents.cidr_id == cidr.id) &&
             !cidrs.iter().any(
                 |cidr2| matches!(cidr2.contents.parent, Some(parent_id) if parent_id == cidr.id)

--- a/shared/src/types.rs
+++ b/shared/src/types.rs
@@ -338,6 +338,17 @@ pub struct AddCidrOpts {
 }
 
 #[derive(Debug, Clone, PartialEq, StructOpt)]
+pub struct DeleteCidrOpts {
+    /// The CIDR name (eg. "engineers")
+    #[structopt(long)]
+    pub name: Option<String>,
+
+    /// Bypass confirmation
+    #[structopt(long)]
+    pub yes: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, StructOpt)]
 pub struct AddAssociationOpts {
     /// The first cidr to associate
     pub cidr1: Option<String>,


### PR DESCRIPTION
This commit adds a `delete-cidr` to both the client and server. It walks
through the prompts just like adding a CIDR. Only eligible CIDRs are shown to the user. 
Eligibility requirements are:

- CIDR has no child CIDRs
- CIDR has no assigned peers

Closes #23