### PR TITLE
client,server: adds ability to rename peers

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -7,7 +7,8 @@ use parking_lot::{Mutex, RwLock};
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 use shared::{
-    AddCidrOpts, AddPeerOpts, DeleteCidrOpts, IoErrorContext, NetworkOpt, INNERNET_PUBKEY_HEADER,
+    AddCidrOpts, AddPeerOpts, DeleteCidrOpts, IoErrorContext, NetworkOpt, RenamePeerOpts,
+    INNERNET_PUBKEY_HEADER,
 };
 use std::{
     collections::{HashMap, VecDeque},
@@ -78,6 +79,14 @@ enum Command {
 
         #[structopt(flatten)]
         args: AddPeerOpts,
+    },
+
+    /// Rename an existing peer.
+    RenamePeer {
+        interface: Interface,
+
+        #[structopt(flatten)]
+        args: RenamePeerOpts,
     },
 
     /// Add a new CIDR to an existing network.
@@ -230,6 +239,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             network: routing,
         } => serve(*interface, &conf, routing).await?,
         Command::AddPeer { interface, args } => add_peer(&interface, &conf, args, opt.network)?,
+        Command::RenamePeer { interface, args } => rename_peer(&interface, &conf, args)?,
         Command::AddCidr { interface, args } => add_cidr(&interface, &conf, args)?,
         Command::DeleteCidr { interface, args } => delete_cidr(&interface, &conf, args)?,
     }
@@ -294,6 +304,30 @@ fn add_peer(
             &SocketAddr::new(config.address, config.listen_port),
             &opts.save_config,
         )?;
+    } else {
+        println!("exited without creating peer.");
+    }
+
+    Ok(())
+}
+
+fn rename_peer(
+    interface: &InterfaceName,
+    conf: &ServerConfig,
+    opts: RenamePeerOpts,
+) -> Result<(), Error> {
+    let conn = open_database_connection(interface, conf)?;
+    let peers = DatabasePeer::list(&conn)?
+        .into_iter()
+        .map(|dp| dp.inner)
+        .collect::<Vec<_>>();
+
+    if let Some((peer_request, old_name)) = shared::prompts::rename_peer(&peers, &opts)? {
+        let mut db_peer = DatabasePeer::list(&conn)?
+            .into_iter()
+            .find(|p| p.name == old_name)
+            .ok_or_else(|| "Peer not found.")?;
+        let _peer = db_peer.update(&conn, peer_request)?;
     } else {
         println!("exited without creating peer.");
     }

--- a/shared/src/types.rs
+++ b/shared/src/types.rs
@@ -319,6 +319,21 @@ pub struct AddPeerOpts {
 }
 
 #[derive(Debug, Clone, PartialEq, StructOpt)]
+pub struct RenamePeerOpts {
+    /// Name of peer to rename
+    #[structopt(long)]
+    pub name: Option<Hostname>,
+
+    /// The new name of the peer
+    #[structopt(long)]
+    pub new_name: Option<Hostname>,
+
+    /// Bypass confirmation
+    #[structopt(long)]
+    pub yes: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, StructOpt)]
 pub struct AddCidrOpts {
     /// The CIDR name (eg. "engineers")
     #[structopt(long)]


### PR DESCRIPTION
This commit adds a subcommand to both the client and server to allow
changing the name of a peer. The peer retains all the same attributes as
before (public keys, IPs, admin/disabled status, etc.).

Closes #87