### PR TITLE
client: support running as non-root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,6 @@ dependencies = [
  "indoc",
  "ipnetwork",
  "lazy_static",
- "libc",
  "log",
  "regex",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,6 +576,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "netlink-packet-core"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac48279d5062bdf175bdbcb6b58ff1d6b0ecd54b951f7a0ff4bc0550fe903ccb"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "libc",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da1bf86b4324996fb58f8e17752b2a06176f4c5efc013928060ac94a3a329b71"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "byteorder",
+ "libc",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-utils"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2afb159d0e3ac700e85f0df25b8438b99d43ed0c0b685242fcdf1b5673e54d"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "paste",
+ "thiserror",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c5374735aa0cd07cb7fd820b656062b187b5588d79517f72956b57c6de9ef"
+dependencies = [
+ "libc",
+ "log",
+]
+
+[[package]]
 name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,6 +682,12 @@ dependencies = [
  "smallvec",
  "winapi",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
 
 [[package]]
 name = "peeking_take_while"
@@ -934,7 +988,11 @@ dependencies = [
  "indoc",
  "ipnetwork",
  "lazy_static",
+ "libc",
  "log",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-sys",
  "publicip",
  "regex",
  "serde",
@@ -942,6 +1000,7 @@ dependencies = [
  "toml",
  "url",
  "wgctrl",
+ "wgctrl-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,9 +383,6 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hostsfile"
 version = "1.1.0"
-dependencies = [
- "tempfile",
-]
 
 [[package]]
 name = "http"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,7 @@ dependencies = [
 name = "client"
 version = "1.3.1"
 dependencies = [
+ "anyhow",
  "colored",
  "dialoguer",
  "hostsfile",
@@ -381,7 +382,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hostsfile"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "tempfile",
 ]
@@ -983,6 +984,7 @@ dependencies = [
 name = "shared"
 version = "1.3.1"
 dependencies = [
+ "anyhow",
  "colored",
  "dialoguer",
  "indoc",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -14,6 +14,7 @@ name = "innernet"
 path = "src/main.rs"
 
 [dependencies]
+anyhow = "1"
 colored = "2"
 dialoguer = "0.8"
 hostsfile = { path = "../hostsfile" }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -20,7 +20,6 @@ hostsfile = { path = "../hostsfile" }
 indoc = "1"
 ipnetwork = { git = "https://github.com/mcginty/ipnetwork" } # pending https://github.com/achanda/ipnetwork/pull/129
 lazy_static = "1"
-libc = "0.2"
 log = "0.4"
 regex = { version = "1", default-features = false, features = ["std"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1028,10 +1028,6 @@ fn run(opt: Opts) -> Result<(), Error> {
         interface: None,
     });
 
-    if unsafe { libc::getuid() } != 0 && !matches!(command, Command::Completions { .. }) {
-        return Err("innernet must run as root.".into());
-    }
-
     match command {
         Command::Install {
             invite,

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,3 +1,4 @@
+use anyhow::{anyhow, bail};
 use colored::*;
 use dialoguer::{Confirm, Input};
 use hostsfile::HostsBuilder;
@@ -6,7 +7,7 @@ use shared::{
     interface_config::InterfaceConfig, prompts, AddAssociationOpts, AddCidrOpts, AddPeerOpts,
     Association, AssociationContents, Cidr, CidrTree, DeleteCidrOpts, EndpointContents,
     InstallOpts, Interface, IoErrorContext, NetworkOpt, Peer, RedeemContents, RenamePeerOpts,
-    State, CLIENT_CONFIG_DIR, REDEEM_TRANSITION_WAIT,
+    State, WrappedIoError, CLIENT_CONFIG_DIR, REDEEM_TRANSITION_WAIT,
 };
 use std::{
     fmt, io,
@@ -245,7 +246,9 @@ fn update_hosts_file(
             &format!("{}.{}.wg", peer.contents.name, interface),
         );
     }
-    hosts_builder.write_to(hosts_path)?;
+    if let Err(e) = hosts_builder.write_to(&hosts_path).with_path(hosts_path) {
+        log::warn!("failed to update hosts ({})", e);
+    }
 
     Ok(())
 }
@@ -272,7 +275,7 @@ fn install(
 
     let target_conf = CLIENT_CONFIG_DIR.join(&iface).with_extension("conf");
     if target_conf.exists() {
-        return Err("An interface with this name already exists in innernet.".into());
+        bail!("An interface with this name already exists in innernet.");
     }
 
     let iface = iface.parse()?;
@@ -423,11 +426,10 @@ fn fetch(
 
     if !interface_up {
         if !bring_up_interface {
-            return Err(format!(
+            bail!(
                 "Interface is not up. Use 'innernet up {}' instead",
                 interface
-            )
-            .into());
+            );
         }
 
         log::info!("bringing up the interface.");
@@ -647,7 +649,7 @@ fn rename_peer(interface: &InterfaceName, opts: RenamePeerOpts) -> Result<(), Er
             .filter(|p| p.name == old_name)
             .map(|p| p.id)
             .next()
-            .ok_or("Peer not found.")?;
+            .ok_or(anyhow!("Peer not found."))?;
 
         let _ = api.http_form("PUT", &format!("/admin/peers/{}", id), peer_request)?;
         log::info!("Peer renamed.");
@@ -687,11 +689,11 @@ fn add_association(interface: &InterfaceName, opts: AddAssociationOpts) -> Resul
         let cidr1 = cidrs
             .iter()
             .find(|c| &c.name == cidr1)
-            .ok_or(format!("can't find cidr '{}'", cidr1))?;
+            .ok_or(anyhow!("can't find cidr '{}'", cidr1))?;
         let cidr2 = cidrs
             .iter()
             .find(|c| &c.name == cidr2)
-            .ok_or(format!("can't find cidr '{}'", cidr2))?;
+            .ok_or(anyhow!("can't find cidr '{}'", cidr2))?;
         (cidr1, cidr2)
     } else if let Some((cidr1, cidr2)) = prompts::add_association(&cidrs[..])? {
         (cidr1, cidr2)
@@ -835,35 +837,7 @@ fn show(
                 Err(e) => Some(Err(e)),
             }
         })
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| {
-            if e.raw_os_error() == Some(1) {
-                let current_exe = std::env::current_exe()
-                    .ok()
-                    .map(|s| s.to_string_lossy().to_string())
-                    .unwrap_or_else(|| "<innernet path>".into());
-                eprintdoc!(
-                    "{}: innernet can't access the device info.
-
-                        You either need to run innernet as root, or give innernet CAP_NET_ADMIN capabilities:
-
-                            sudo setcap cap_net_admin+eip {}
-                    ",
-                    "ERROR".bold().red(),
-                    current_exe
-                );
-            } else if e.kind() == io::ErrorKind::PermissionDenied {
-                eprintdoc!(
-                    "{}: innernet can't access its config/data folders.
-
-                        You either need to run innernet as root, or give the user running innernet permissions
-                        to access /etc/innernet and /var/lib/innernet.
-                    ",
-                    "ERROR".bold().red(),
-                );
-            }
-            e
-        })?;
+        .collect::<Result<Vec<_>, _>>()?;
 
     if devices.is_empty() {
         log::info!("No innernet networks currently running.");
@@ -876,7 +850,7 @@ fn show(
         let me = peers
             .iter()
             .find(|p| p.public_key == device_info.public_key.as_ref().unwrap().to_base64())
-            .ok_or("missing peer info")?;
+            .ok_or(anyhow!("missing peer info"))?;
 
         let mut peer_states = device_info
             .peers
@@ -888,7 +862,7 @@ fn show(
                         peer,
                         info: Some(info),
                     }),
-                    None => Err(format!("peer {} isn't an innernet peer.", public_key)),
+                    None => Err(anyhow!("peer {} isn't an innernet peer.", public_key)),
                 }
             })
             .collect::<Result<Vec<PeerState>, _>>()?;
@@ -1017,6 +991,9 @@ fn main() {
     if let Err(e) = run(opt) {
         println!();
         log::error!("{}\n", e);
+        if let Some(e) = e.downcast_ref::<WrappedIoError>() {
+            util::permissions_helptext(e);
+        }
         std::process::exit(1);
     }
 }

--- a/hostsfile/Cargo.toml
+++ b/hostsfile/Cargo.toml
@@ -8,4 +8,3 @@ publish = false
 version = "1.1.0"
 
 [dependencies]
-tempfile = "3"

--- a/hostsfile/Cargo.toml
+++ b/hostsfile/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 license = "UNLICENSED"
 name = "hostsfile"
 publish = false
-version = "1.0.1"
+version = "1.1.0"
 
 [dependencies]
 tempfile = "3"

--- a/hostsfile/src/lib.rs
+++ b/hostsfile/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt, fs::OpenOptions, io::{self, BufRead, BufReader, ErrorKind, Write}, mem, net::IpAddr, path::{Path, PathBuf}, result};
+use std::{collections::HashMap, fmt, fs::OpenOptions, io::{self, BufRead, BufReader, ErrorKind, Write}, net::IpAddr, path::{Path, PathBuf}, result};
 
 pub type Result<T> = result::Result<T, Box<dyn std::error::Error>>;
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -13,6 +13,7 @@ name = "innernet-server"
 path = "src/main.rs"
 
 [dependencies]
+anyhow = "1"
 bytes = "1"
 colored = "2"
 dialoguer = "0.8"

--- a/server/src/api/admin/peer.rs
+++ b/server/src/api/admin/peer.rs
@@ -229,7 +229,7 @@ mod tests {
         let old_peer = DatabasePeer::get(&server.db.lock(), test::DEVELOPER1_PEER_ID)?;
 
         let change = PeerContents {
-            name: "new-peer-name".parse()?,
+            name: "new-peer-name".parse().unwrap(),
             ..old_peer.contents.clone()
         };
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,3 +1,4 @@
+use anyhow::{anyhow, bail};
 use colored::*;
 use dialoguer::Confirm;
 use hyper::{http, server::conn::AddrStream, Body, Request, Response};
@@ -261,14 +262,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn open_database_connection(
     interface: &InterfaceName,
     conf: &ServerConfig,
-) -> Result<rusqlite::Connection, Box<dyn std::error::Error>> {
+) -> Result<rusqlite::Connection, Error> {
     let database_path = conf.database_path(&interface);
     if !Path::new(&database_path).exists() {
-        return Err(format!(
+        bail!(
             "no database file found at {}",
             database_path.to_string_lossy()
-        )
-        .into());
+        );
     }
 
     let conn = Connection::open(&database_path)?;
@@ -337,7 +337,7 @@ fn rename_peer(
         let mut db_peer = DatabasePeer::list(&conn)?
             .into_iter()
             .find(|p| p.name == old_name)
-            .ok_or("Peer not found.")?;
+            .ok_or(anyhow!("Peer not found."))?;
         let _peer = db_peer.update(&conn, peer_request)?;
     } else {
         println!("exited without creating peer.");

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -337,7 +337,7 @@ fn rename_peer(
         let mut db_peer = DatabasePeer::list(&conn)?
             .into_iter()
             .find(|p| p.name == old_name)
-            .ok_or( "Peer not found.")?;
+            .ok_or("Peer not found.")?;
         let _peer = db_peer.update(&conn, peer_request)?;
     } else {
         println!("exited without creating peer.");

--- a/server/src/test.rs
+++ b/server/src/test.rs
@@ -221,7 +221,7 @@ pub fn peer_contents(
     let public_key = KeyPair::generate().public;
 
     Ok(PeerContents {
-        name: name.parse()?,
+        name: name.parse().map_err(|e: &str| anyhow!(e))?,
         ip: ip_str.parse()?,
         cidr_id,
         public_key: public_key.to_base64(),

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -12,6 +12,7 @@ dialoguer = "0.8"
 indoc = "1"
 ipnetwork = { git = "https://github.com/mcginty/ipnetwork" } # pending https://github.com/achanda/ipnetwork/pull/129
 lazy_static = "1"
+libc = "0.2"
 log = "0.4"
 publicip = { path = "../publicip" }
 regex = "1"
@@ -20,3 +21,9 @@ structopt = "0.3"
 toml = "0.5"
 url = "2"
 wgctrl = { path = "../wgctrl-rs" }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+netlink-sys = "0.6"
+netlink-packet-core = "0.2"
+netlink-packet-route = "0.7"
+wgctrl-sys = { path = "../wgctrl-sys" }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 version = "1.3.1"
 
 [dependencies]
+anyhow = "1"
 colored = "2.0"
 dialoguer = "0.8"
 indoc = "1"

--- a/shared/src/interface_config.rs
+++ b/shared/src/interface_config.rs
@@ -116,14 +116,7 @@ impl InterfaceConfig {
 
     pub fn from_interface(interface: &InterfaceName) -> Result<Self, Error> {
         let path = Self::build_config_file_path(interface)?;
-        let file = File::open(&path).with_path(&path)?;
-        if crate::chmod(&file, 0o600)? {
-            println!(
-                "{} updated permissions for {} to 0600.",
-                "[!]".yellow(),
-                path.display()
-            );
-        }
+        crate::warn_on_dangerous_mode(&path).with_path(&path)?;
         Self::from_file(path)
     }
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -9,11 +9,11 @@ use std::{
 };
 
 pub mod interface_config;
+#[cfg(target_os = "linux")]
+mod netlink;
 pub mod prompts;
 pub mod types;
 pub mod wg;
-#[cfg(target_os = "linux")]
-mod netlink;
 
 pub use types::*;
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -12,6 +12,8 @@ pub mod interface_config;
 pub mod prompts;
 pub mod types;
 pub mod wg;
+#[cfg(target_os = "linux")]
+mod netlink;
 
 pub use types::*;
 

--- a/shared/src/netlink.rs
+++ b/shared/src/netlink.rs
@@ -1,4 +1,5 @@
 use crate::Error;
+use anyhow::anyhow;
 use ipnetwork::IpNetwork;
 use netlink_packet_core::{
     NetlinkMessage, NetlinkPayload, NLM_F_ACK, NLM_F_CREATE, NLM_F_EXCL, NLM_F_REQUEST,
@@ -13,7 +14,7 @@ use wgctrl::InterfaceName;
 
 fn if_nametoindex(interface: &InterfaceName) -> Result<u32, Error> {
     match unsafe { libc::if_nametoindex(interface.as_ptr()) } {
-        0 => Err(format!("couldn't find interface '{}'.", interface).into()),
+        0 => Err(anyhow!("couldn't find interface '{}'.", interface)),
         index => Ok(index),
     }
 }
@@ -29,7 +30,7 @@ fn netlink_call(
     req.serialize(&mut buf);
     let len = req.buffer_len();
 
-    log::debug!("request: {:?}", req);
+    log::debug!("netlink request: {:?}", req);
     let socket = Socket::new(NETLINK_ROUTE).unwrap();
     let kernel_addr = SocketAddr::new(0, 0);
     socket.connect(&kernel_addr)?;

--- a/shared/src/netlink.rs
+++ b/shared/src/netlink.rs
@@ -4,42 +4,26 @@ use netlink_packet_core::{
     NetlinkMessage, NetlinkPayload, NLM_F_ACK, NLM_F_CREATE, NLM_F_EXCL, NLM_F_REQUEST,
 };
 use netlink_packet_route::{
-    constants::*, route::Nla, RouteHeader, RouteMessage, RtnlMessage, RTN_UNICAST, RT_SCOPE_LINK,
-    RT_TABLE_MAIN,
+    address, constants::*, link, route, AddressHeader, AddressMessage, LinkHeader, LinkMessage,
+    RouteHeader, RouteMessage, RtnlMessage, RTN_UNICAST, RT_SCOPE_LINK, RT_TABLE_MAIN,
 };
 use netlink_sys::{protocols::NETLINK_ROUTE, Socket, SocketAddr};
+use std::io;
 use wgctrl::InterfaceName;
 
-pub fn add_route(interface: &InterfaceName, cidr: IpNetwork) -> Result<bool, Error> {
-    let if_index = unsafe { libc::if_nametoindex(interface.as_ptr()) };
-    if if_index == 0 {
-        return Err("add_route: couldn't find interface with that name.".into());
+fn if_nametoindex(interface: &InterfaceName) -> Result<u32, Error> {
+    match unsafe { libc::if_nametoindex(interface.as_ptr()) } {
+        0 => Err(format!("couldn't find interface '{}'.", interface).into()),
+        index => Ok(index),
     }
-    let mut message = RouteMessage {
-        header: RouteHeader {
-            table: RT_TABLE_MAIN,
-            protocol: RTPROT_BOOT,
-            scope: RT_SCOPE_LINK,
-            kind: RTN_UNICAST,
-            address_family: AF_INET as u8,
-            destination_prefix_length: cidr.prefix(),
-            ..Default::default()
-        },
-        nlas: vec![],
-    };
-    match cidr {
-        IpNetwork::V4(network) => {
-            let dst = network.ip().octets().to_vec();
-            message.nlas.push(Nla::Destination(dst))
-        },
-        IpNetwork::V6(network) => {
-            let dst = network.ip().octets().to_vec();
-            message.nlas.push(Nla::Destination(dst))
-        },
-    }
-    message.nlas.push(Nla::Oif(if_index));
-    let mut req = NetlinkMessage::from(RtnlMessage::NewRoute(message));
-    req.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_EXCL | NLM_F_CREATE;
+}
+
+fn netlink_call(
+    message: RtnlMessage,
+    flags: Option<u16>,
+) -> Result<NetlinkMessage<RtnlMessage>, io::Error> {
+    let mut req = NetlinkMessage::from(message);
+    req.header.flags = flags.unwrap_or(NLM_F_REQUEST | NLM_F_ACK | NLM_F_EXCL | NLM_F_CREATE);
     req.finalize();
     let mut buf = [0; 4096];
     req.serialize(&mut buf);
@@ -51,16 +35,93 @@ pub fn add_route(interface: &InterfaceName, cidr: IpNetwork) -> Result<bool, Err
     socket.connect(&kernel_addr)?;
     let n_sent = socket.send(&buf[..len], 0).unwrap();
     if n_sent != len {
-        return Err("failed to send netlink request".into());
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "failed to send netlink request",
+        ));
     }
 
     let n_received = socket.recv(&mut buf[..], 0).unwrap();
-    log::debug!("response bytes: {:?}", &buf[..n_received]);
-    let response = NetlinkMessage::<RtnlMessage>::deserialize(&buf[..n_received])?;
-    log::debug!("response: {:?}", response);
+    let response = NetlinkMessage::<RtnlMessage>::deserialize(&buf[..n_received])
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    log::trace!("netlink response: {:?}", response);
     if let NetlinkPayload::Error(e) = response.payload {
-        return Err(format!("netlink error {}", e.code).into());
+        return Err(e.to_io());
     }
+    Ok(response)
+}
 
-    Ok(false)
+pub fn set_up(interface: &InterfaceName, mtu: u32) -> Result<(), Error> {
+    let index = if_nametoindex(interface)?;
+    let message = LinkMessage {
+        header: LinkHeader {
+            index,
+            flags: IFF_UP,
+            ..Default::default()
+        },
+        nlas: vec![link::nlas::Nla::Mtu(mtu)],
+    };
+    netlink_call(RtnlMessage::SetLink(message), None)?;
+    Ok(())
+}
+
+pub fn set_addr(interface: &InterfaceName, addr: IpNetwork) -> Result<(), Error> {
+    let index = if_nametoindex(interface)?;
+    let (family, nlas) = match addr {
+        IpNetwork::V4(network) => {
+            let addr_bytes = network.ip().octets().to_vec();
+            (
+                AF_INET as u8,
+                vec![
+                    address::Nla::Local(addr_bytes.clone()),
+                    address::Nla::Address(addr_bytes),
+                ],
+            )
+        },
+        IpNetwork::V6(network) => (
+            AF_INET6 as u8,
+            vec![address::Nla::Address(network.ip().octets().to_vec())],
+        ),
+    };
+    let message = AddressMessage {
+        header: AddressHeader {
+            index,
+            family,
+            prefix_len: addr.prefix(),
+            scope: RT_SCOPE_UNIVERSE,
+            ..Default::default()
+        },
+        nlas,
+    };
+    netlink_call(
+        RtnlMessage::NewAddress(message),
+        Some(NLM_F_REQUEST | NLM_F_ACK | NLM_F_REPLACE | NLM_F_CREATE),
+    )?;
+    Ok(())
+}
+
+pub fn add_route(interface: &InterfaceName, cidr: IpNetwork) -> Result<bool, Error> {
+    let if_index = if_nametoindex(interface)?;
+    let (address_family, dst) = match cidr {
+        IpNetwork::V4(network) => (AF_INET as u8, network.network().octets().to_vec()),
+        IpNetwork::V6(network) => (AF_INET6 as u8, network.network().octets().to_vec()),
+    };
+    let message = RouteMessage {
+        header: RouteHeader {
+            table: RT_TABLE_MAIN,
+            protocol: RTPROT_BOOT,
+            scope: RT_SCOPE_LINK,
+            kind: RTN_UNICAST,
+            destination_prefix_length: cidr.prefix(),
+            address_family,
+            ..Default::default()
+        },
+        nlas: vec![route::Nla::Destination(dst), route::Nla::Oif(if_index)],
+    };
+
+    match netlink_call(RtnlMessage::NewRoute(message), None) {
+        Ok(_) => Ok(true),
+        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => Ok(false),
+        Err(e) => Err(e.into()),
+    }
 }

--- a/shared/src/netlink.rs
+++ b/shared/src/netlink.rs
@@ -1,0 +1,65 @@
+use crate::{Error, IoErrorContext, NetworkOpt};
+use ipnetwork::IpNetwork;
+use netlink_packet_core::{NLM_F_ACK, NLM_F_CREATE, NLM_F_EXCL, NLM_F_REQUEST, NetlinkMessage, NetlinkPayload};
+use netlink_packet_route::{constants::*, RTN_UNICAST, RTPROT_STATIC, RT_SCOPE_LINK, RT_TABLE_MAIN, RouteHeader, RouteMessage, RtnlMessage, route::Nla};
+use netlink_sys::{protocols::NETLINK_ROUTE, Socket, SocketAddr};
+use std::{
+    net::{IpAddr},
+    process::{self, Command},
+};
+use wgctrl::{Backend, Device, DeviceUpdate, InterfaceName, PeerConfigBuilder};
+
+pub fn add_route(interface: &InterfaceName, cidr: IpNetwork) -> Result<bool, Error> {
+    let if_index = unsafe { libc::if_nametoindex(interface.as_ptr()) };
+    if if_index == 0 {
+        return Err("add_route: couldn't find interface with that name.".into());
+    }
+    let mut message = RouteMessage {
+            header: RouteHeader {
+                table: RT_TABLE_MAIN,
+                protocol: RTPROT_BOOT,
+                scope: RT_SCOPE_LINK,
+                kind: RTN_UNICAST,
+                address_family: AF_INET as u8,
+                destination_prefix_length: cidr.prefix(),
+                ..Default::default()
+            },
+            nlas: vec![],
+        };
+    match cidr {
+        IpNetwork::V4(network) => {
+            let dst = network.ip().octets().to_vec();
+            message.nlas.push(Nla::Destination(dst))
+        }
+        IpNetwork::V6(network) => {
+            let dst = network.ip().octets().to_vec();
+            message.nlas.push(Nla::Destination(dst))
+        }
+    }
+    message.nlas.push(Nla::Oif(if_index));
+    let mut req = NetlinkMessage::from(RtnlMessage::NewRoute(message));
+    req.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_EXCL | NLM_F_CREATE;
+    req.finalize();
+    let mut buf = [0; 4096];
+    req.serialize(&mut buf);
+    let len = req.buffer_len();
+
+    log::debug!("request: {:?}", req);
+    let socket = Socket::new(NETLINK_ROUTE).unwrap();
+    let kernel_addr = SocketAddr::new(0, 0);
+    socket.connect(&kernel_addr)?;
+    let n_sent = socket.send(&buf[..len], 0).unwrap();
+    if n_sent != len {
+        return Err("failed to send netlink request".into());
+    }
+
+    let n_received = socket.recv(&mut buf[..], 0).unwrap();
+    log::debug!("response bytes: {:?}", &buf[..n_received]);
+    let response = NetlinkMessage::<RtnlMessage>::deserialize(&buf[..n_received])?;
+    log::debug!("response: {:?}", response);
+    if let NetlinkPayload::Error(e) = response.payload {
+        return Err(format!("netlink error {}", e.code).into())
+    }
+
+    Ok(false)
+}

--- a/shared/src/types.rs
+++ b/shared/src/types.rs
@@ -4,6 +4,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::{
     fmt::{self, Display, Formatter},
+    io,
     net::{IpAddr, SocketAddr, ToSocketAddrs},
     ops::Deref,
     path::Path,
@@ -121,14 +122,14 @@ impl fmt::Display for Endpoint {
 }
 
 impl Endpoint {
-    pub fn resolve(&self) -> Result<SocketAddr, String> {
-        let mut addrs = self
-            .to_string()
-            .to_socket_addrs()
-            .map_err(|e| e.to_string())?;
-        addrs
-            .next()
-            .ok_or_else(|| "failed to resolve address".to_string())
+    pub fn resolve(&self) -> Result<SocketAddr, io::Error> {
+        let mut addrs = self.to_string().to_socket_addrs()?;
+        addrs.next().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::AddrNotAvailable,
+                "failed to resolve address".to_string(),
+            )
+        })
     }
 }
 

--- a/shared/src/wg.rs
+++ b/shared/src/wg.rs
@@ -38,12 +38,14 @@ pub fn set_addr(interface: &InterfaceName, addr: IpNetwork) -> Result<(), Error>
                 &addr.ip().to_string(),
                 "alias",
             ],
-        ).map(|_output| ())
+        )
+        .map(|_output| ())
     } else {
         cmd(
             "ifconfig",
             &[&real_interface, "inet6", &addr.to_string(), "alias"],
-        ).map(|_output| ())
+        )
+        .map(|_output| ())
     }
 }
 

--- a/shared/src/wg.rs
+++ b/shared/src/wg.rs
@@ -146,17 +146,6 @@ pub fn add_route(interface: &InterfaceName, cidr: IpNetwork) -> Result<bool, Err
             Ok(!stderr.contains("File exists"))
         }
     } else {
-        // TODO(mcginty): use the netlink interface on linux to modify routing table.
-        let _ = cmd(
-            "ip",
-            &[
-                "route",
-                "add",
-                &IpNetwork::new(cidr.network(), cidr.prefix())?.to_string(),
-                "dev",
-                &interface.to_string(),
-            ],
-        );
-        Ok(false)
+        super::netlink::add_route(interface, cidr)
     }
 }

--- a/shared/src/wg.rs
+++ b/shared/src/wg.rs
@@ -1,12 +1,11 @@
 use crate::{Error, IoErrorContext, NetworkOpt};
 use ipnetwork::IpNetwork;
-use std::{
-    net::{IpAddr, SocketAddr},
-    process::{self, Command},
-};
+use std::net::{IpAddr, SocketAddr};
 use wgctrl::{Backend, Device, DeviceUpdate, InterfaceName, PeerConfigBuilder};
 
+#[cfg(target_os = "macos")]
 fn cmd(bin: &str, args: &[&str]) -> Result<process::Output, Error> {
+    use process::{self, Command};
     let output = Command::new(bin).args(args).output()?;
     log::debug!("cmd: {} {}", bin, args.join(" "));
     log::debug!("status: {:?}", output.status.code());
@@ -47,23 +46,19 @@ pub fn set_addr(interface: &InterfaceName, addr: IpNetwork) -> Result<(), Error>
             &[&real_interface, "inet6", &addr.to_string(), "alias"],
         )?;
     }
-    cmd("ifconfig", &[&real_interface, "mtu", "1420"])?;
+}
+
+#[cfg(target_os = "macos")]
+pub fn set_up(interface: &InterfaceName, mtu: u32) -> Result<(), Error> {
+    cmd("ifconfig", &[&real_interface, "mtu", mtu.to_string()])?;
     Ok(())
 }
 
 #[cfg(target_os = "linux")]
-pub fn set_addr(interface: &InterfaceName, addr: IpNetwork) -> Result<(), Error> {
-    let interface = interface.to_string();
-    cmd(
-        "ip",
-        &["address", "replace", &addr.to_string(), "dev", &interface],
-    )?;
-    cmd(
-        "ip",
-        &["link", "set", "mtu", "1420", "up", "dev", &interface],
-    )?;
-    Ok(())
-}
+pub use super::netlink::set_addr;
+
+#[cfg(target_os = "linux")]
+pub use super::netlink::set_up;
 
 pub fn up(
     interface: &InterfaceName,
@@ -88,6 +83,7 @@ pub fn up(
         .set_private_key(wgctrl::Key::from_base64(&private_key).unwrap())
         .apply(interface, network.backend)?;
     set_addr(interface, address)?;
+    set_up(interface, 1420)?;
     if !network.no_routing {
         add_route(interface, address)?;
     }
@@ -120,32 +116,32 @@ pub fn down(interface: &InterfaceName, backend: Backend) -> Result<(), Error> {
 /// Add a route in the OS's routing table to get traffic flowing through this interface.
 /// Returns an error if the process doesn't exit successfully, otherwise returns
 /// true if the route was changed, false if the route already exists.
+#[cfg(target_os = "macos")]
 pub fn add_route(interface: &InterfaceName, cidr: IpNetwork) -> Result<bool, Error> {
-    if cfg!(target_os = "macos") {
-        let real_interface =
-            wgctrl::backends::userspace::resolve_tun(interface).with_str(interface.to_string())?;
-        let output = cmd(
-            "route",
-            &[
-                "-n",
-                "add",
-                if cidr.is_ipv4() { "-inet" } else { "-inet6" },
-                &cidr.to_string(),
-                "-interface",
-                &real_interface,
-            ],
-        )?;
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        if !output.status.success() {
-            Err(format!(
-                "failed to add route for device {} ({}): {}",
-                &interface, real_interface, stderr
-            )
-            .into())
-        } else {
-            Ok(!stderr.contains("File exists"))
-        }
+    let real_interface =
+        wgctrl::backends::userspace::resolve_tun(interface).with_str(interface.to_string())?;
+    let output = cmd(
+        "route",
+        &[
+            "-n",
+            "add",
+            if cidr.is_ipv4() { "-inet" } else { "-inet6" },
+            &cidr.to_string(),
+            "-interface",
+            &real_interface,
+        ],
+    )?;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !output.status.success() {
+        Err(format!(
+            "failed to add route for device {} ({}): {}",
+            &interface, real_interface, stderr
+        )
+        .into())
     } else {
-        super::netlink::add_route(interface, cidr)
+        Ok(!stderr.contains("File exists"))
     }
 }
+
+#[cfg(target_os = "linux")]
+pub use super::netlink::add_route;

--- a/shared/src/wg.rs
+++ b/shared/src/wg.rs
@@ -13,13 +13,12 @@ fn cmd(bin: &str, args: &[&str]) -> Result<std::process::Output, Error> {
     if output.status.success() {
         Ok(output)
     } else {
-        Err(format!(
+        Err(anyhow::anyhow!(
             "failed to run {} {} command: {}",
             bin,
             args.join(" "),
             String::from_utf8_lossy(&output.stderr)
-        )
-        .into())
+        ))
     }
 }
 
@@ -136,11 +135,10 @@ pub fn add_route(interface: &InterfaceName, cidr: IpNetwork) -> Result<bool, Err
     )?;
     let stderr = String::from_utf8_lossy(&output.stderr);
     if !output.status.success() {
-        Err(format!(
+        Err(anyhow::anyhow!(
             "failed to add route for device {} ({}): {}",
             &interface, real_interface, stderr
-        )
-        .into())
+        ))
     } else {
         Ok(!stderr.contains("File exists"))
     }

--- a/wgctrl-rs/src/device.rs
+++ b/wgctrl-rs/src/device.rs
@@ -165,7 +165,7 @@ impl InterfaceName {
 
     #[cfg(target_os = "linux")]
     /// Returns a pointer to the inner byte buffer for FFI calls.
-    pub(crate) fn as_ptr(&self) -> *const c_char {
+    pub fn as_ptr(&self) -> *const c_char {
         self.0.as_ptr()
     }
 


### PR DESCRIPTION
This is a work-in-progress change to have the client support running as non-root, including better messaging around permission/access issues.

# Example configurations

## Linux
```sh
sudo cap_net_admin+eip $(which innernet)
sudo chown -R $USER /etc/innernet
sudo chown -R $USER /var/lib/innernet
```

## macOS
There are no "capabilities" in macOS, so subcommands like `up` and `install` will still require root.
```sh
sudo chown -R $USER /etc/innernet
sudo chown -R $USER /var/lib/innernet
sudo chown -R $USER /var/run/wireguard
```
