### PR TITLE
Exit with code 1 (error) if wizard failed.

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -237,6 +237,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Command::New { opts } => {
             if let Err(e) = initialize::init_wizard(&conf, opts) {
                 println!("{}: {}.", "creation failed".red(), e);
+                std::process::exit(1);
             }
         },
         Command::Uninstall { interface } => uninstall(&interface, &conf, opt.network)?,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -236,7 +236,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match opt.command {
         Command::New { opts } => {
             if let Err(e) = initialize::init_wizard(&conf, opts) {
-                println!("{}: {}.", "creation failed".red(), e);
+                eprintln!("{}: {}.", "creation failed".red(), e);
                 std::process::exit(1);
             }
         },


### PR DESCRIPTION
I started to automate (1.3.0) and found that my code is 'ok' when there are errors in stdout.
I found that message 
`creation failed: failed to create database (are you not running as root?).`
is not causing non-zero exit code.

This fix should handle all `init_wizard` errors.

Also, the error message now is printed to stderr instead of stdout.