### PR TITLE
Refactor PeerDiff and update peer endpoints only when they seem disconnected

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,9 +62,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bindgen"
-version = "0.58.1"
+version = "0.59.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8523b410d7187a43085e7e064416ea32ded16bd0a4e6fc025e21616d01258f"
+checksum = "453c49e5950bb0eb63bb3df640e31618846c89d5b7faa54040d76e98e0134375"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -86,6 +86,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitvec"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,9 +117,9 @@ checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 
 [[package]]
 name = "cexpr"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
+checksum = "db507a7679252d2276ed0dd8113c6875ec56d3089f9225b2b42c30cc1f8e5c89"
 dependencies = [
  "nom",
 ]
@@ -276,6 +288,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures-channel"
@@ -613,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-sys"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c5374735aa0cd07cb7fd820b656062b187b5588d79517f72956b57c6de9ef"
+checksum = "f48ea34ea0678719815c3753155067212f853ad2d8ef4a49167bae7f7c254188"
 dependencies = [
  "libc",
  "log",
@@ -623,10 +641,12 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "5.1.2"
+version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
 dependencies = [
+ "bitvec",
+ "funty",
  "memchr",
  "version_check",
 ]
@@ -784,6 +804,12 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
@@ -1063,6 +1089,12 @@ dependencies = [
  "syn",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -1369,6 +1401,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "x25519-dalek"

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -501,7 +501,7 @@ fn fetch(
                 .iter()
                 .find(|p| p.config.public_key.to_base64() == peer.public_key);
 
-            Some(PeerDiff::new(existing_peer.map(|p| &p.config), Some(peer)).unwrap())
+            PeerDiff::new(existing_peer.map(|p| &p.config), Some(peer)).unwrap()
         }
     });
 
@@ -511,7 +511,7 @@ fn fetch(
         if peers.iter().any(|p| p.public_key == public_key) {
             None
         } else {
-            Some(PeerDiff::new(Some(&existing.config), None).unwrap())
+            PeerDiff::new(Some(&existing.config), None).unwrap()
         }
     });
 

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -6,8 +6,8 @@ use indoc::eprintdoc;
 use shared::{
     interface_config::InterfaceConfig, prompts, AddAssociationOpts, AddCidrOpts, AddPeerOpts,
     Association, AssociationContents, Cidr, CidrTree, DeleteCidrOpts, EndpointContents,
-    InstallOpts, Interface, IoErrorContext, NetworkOpt, Peer, RedeemContents, RenamePeerOpts,
-    State, WrappedIoError, CLIENT_CONFIG_DIR, REDEEM_TRANSITION_WAIT,
+    InstallOpts, Interface, IoErrorContext, NetworkOpt, Peer, PeerDiff, RedeemContents,
+    RenamePeerOpts, State, WrappedIoError, CLIENT_CONFIG_DIR, REDEEM_TRANSITION_WAIT,
 };
 use std::{
     fmt, io,
@@ -446,10 +446,9 @@ fn fetch(
     network: NetworkOpt,
 ) -> Result<(), Error> {
     let config = InterfaceConfig::from_interface(interface)?;
-    let interface_up = if let Ok(interfaces) = Device::list(network.backend) {
-        interfaces.iter().any(|name| name == interface)
-    } else {
-        false
+    let interface_up = match Device::list(network.backend) {
+        Ok(interfaces) => interfaces.iter().any(|name| name == interface),
+        _ => false,
     };
 
     if !interface_up {
@@ -493,61 +492,66 @@ fn fetch(
         .unwrap_or_default();
     let existing_peers = &device_info.peers;
 
-    let peer_configs_diff = peers
-        .iter()
-        .filter(|peer| !peer.is_disabled && peer.public_key != interface_public_key)
-        .filter_map(|peer| {
+    // Match existing peers (by pubkey) to new peer information from the server.
+    let modifications = peers.iter().filter_map(|peer| {
+        if peer.is_disabled || peer.public_key == interface_public_key {
+            None
+        } else {
             let existing_peer = existing_peers
                 .iter()
                 .find(|p| p.config.public_key.to_base64() == peer.public_key);
 
-            let change = match existing_peer {
-                Some(existing_peer) => peer.diff(&existing_peer.config).map(|diff| {
-                    if let Some(endpoint) = diff.endpoint {
-                        log::debug!("  Peer endpoint changed: {:?}", endpoint);
-                    }
-                    (PeerConfigBuilder::from(&diff), peer, "modified".normal())
-                }),
-                None => Some((PeerConfigBuilder::from(peer), peer, "added".green())),
+            Some(PeerDiff::new(existing_peer.map(|p| &p.config), Some(peer)).unwrap())
+        }
+    });
+
+    // Remove any peers on the interface that aren't in the server's peer list any more.
+    let removals = existing_peers.iter().filter_map(|existing| {
+        let public_key = existing.config.public_key.to_base64();
+        if peers.iter().any(|p| p.public_key == public_key) {
+            None
+        } else {
+            Some(PeerDiff::new(Some(&existing.config), None).unwrap())
+        }
+    });
+
+    let updates = modifications
+        .chain(removals)
+        .inspect(|diff| {
+            let public_key = diff.public_key().to_base64();
+
+            let text = match (diff.old, diff.new) {
+                (None, Some(_)) => "added",
+                (Some(_), Some(_)) => "modified",
+                (Some(_), None) => "removed",
+                _ => unreachable!("PeerDiff can't be None -> None"),
             };
 
-            change.map(|(builder, peer, text)| {
-                println!(
-                    "    peer {} ({}...) was {}.",
-                    peer.name.yellow(),
-                    &peer.public_key[..10].dimmed(),
-                    text
-                );
-                builder
-            })
-        })
-        .collect::<Vec<PeerConfigBuilder>>();
+            let peer_hostname = match diff {
+                PeerDiff {
+                    new: Some(peer), ..
+                } => Some(peer.name.clone()),
+                _ => store
+                    .peers()
+                    .iter()
+                    .find(|p| p.public_key == public_key)
+                    .map(|p| p.name.clone()),
+            };
+            let peer_name = peer_hostname.as_deref().unwrap_or("[unknown]");
 
-    let mut device_config_builder = DeviceUpdate::new();
-    let mut device_config_changed = false;
-
-    if !peer_configs_diff.is_empty() {
-        device_config_builder = device_config_builder.add_peers(&peer_configs_diff);
-        device_config_changed = true;
-    }
-
-    for peer in existing_peers {
-        let public_key = peer.config.public_key.to_base64();
-        if !peers.iter().any(|p| p.public_key == public_key) {
             println!(
-                "    peer ({}...) was {}.",
-                &public_key[..10].yellow(),
-                "removed".red()
+                "    peer {} ({}...) was {}.",
+                peer_name.yellow(),
+                &public_key[..10].dimmed(),
+                text
             );
+        })
+        .map(PeerConfigBuilder::from)
+        .collect::<Vec<_>>();
 
-            device_config_builder =
-                device_config_builder.remove_peer_by_key(&peer.config.public_key);
-            device_config_changed = true;
-        }
-    }
-
-    if device_config_changed {
-        device_config_builder
+    if !updates.is_empty() {
+        DeviceUpdate::new()
+            .add_peers(&updates)
             .apply(interface, network.backend)
             .with_str(interface.to_string())?;
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -25,7 +25,7 @@ url = "2"
 wgctrl = { path = "../wgctrl-rs" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-netlink-sys = "0.6"
+netlink-sys = "0.7"
 netlink-packet-core = "0.2"
 netlink-packet-route = "0.7"
 wgctrl-sys = { path = "../wgctrl-sys" }

--- a/shared/src/wg.rs
+++ b/shared/src/wg.rs
@@ -85,6 +85,7 @@ pub fn up(
                 )
             })?)
             .add_allowed_ip(address, prefix)
+            .set_persistent_keepalive_interval(25)
             .set_endpoint(endpoint);
         device = device.add_peer(peer_config);
     }

--- a/wgctrl-rs/src/backends/kernel.rs
+++ b/wgctrl-rs/src/backends/kernel.rs
@@ -58,7 +58,6 @@ impl<'a> From<&'a wgctrl_sys::wg_peer> for PeerInfo {
                 },
                 rx_bytes: raw.rx_bytes,
                 tx_bytes: raw.tx_bytes,
-                __cant_construct_me: (),
             },
         }
     }

--- a/wgctrl-rs/src/backends/userspace.rs
+++ b/wgctrl-rs/src/backends/userspace.rs
@@ -94,7 +94,6 @@ fn new_peer_info(public_key: Key) -> PeerInfo {
             last_handshake_time: None,
             rx_bytes: 0,
             tx_bytes: 0,
-            __cant_construct_me: (),
         },
     }
 }

--- a/wgctrl-rs/src/config.rs
+++ b/wgctrl-rs/src/config.rs
@@ -120,7 +120,7 @@ impl PeerConfigBuilder {
     }
 
     /// Specifies that this peer does not require keepalive packets.
-    pub fn disable_persistent_keepalive(self) -> Self {
+    pub fn unset_persistent_keepalive(self) -> Self {
         self.set_persistent_keepalive_interval(0)
     }
 

--- a/wgctrl-rs/src/config.rs
+++ b/wgctrl-rs/src/config.rs
@@ -73,6 +73,11 @@ impl PeerConfigBuilder {
         }
     }
 
+    /// The public key used in this builder.
+    pub fn public_key(&self) -> &Key {
+        &self.public_key
+    }
+
     /// Creates a `PeerConfigBuilder` from a [`PeerConfig`](PeerConfig).
     ///
     /// This is mostly a convenience method for cases when you want to copy

--- a/wgctrl-rs/src/device.rs
+++ b/wgctrl-rs/src/device.rs
@@ -12,12 +12,18 @@ use std::{
 };
 
 /// Represents an IP address a peer is allowed to have, in CIDR notation.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct AllowedIp {
     /// The IP address.
     pub address: IpAddr,
     /// The CIDR subnet mask.
     pub cidr: u8,
+}
+
+impl fmt::Debug for AllowedIp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.address, self.cidr)
+    }
 }
 
 impl std::str::FromStr for AllowedIp {

--- a/wgctrl-rs/src/device.rs
+++ b/wgctrl-rs/src/device.rs
@@ -64,7 +64,7 @@ pub struct PeerConfig {
 ///
 /// These are the attributes that will change over time; to update them,
 /// re-read the information from the interface.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct PeerStats {
     /// Time of the last handshake/rekey with this peer.
     pub last_handshake_time: Option<SystemTime>,
@@ -72,7 +72,6 @@ pub struct PeerStats {
     pub rx_bytes: u64,
     /// Number of bytes transmitted to this peer.
     pub tx_bytes: u64,
-    pub(crate) __cant_construct_me: (),
 }
 
 /// Represents the complete status of a peer.

--- a/wgctrl-sys/Cargo.toml
+++ b/wgctrl-sys/Cargo.toml
@@ -13,5 +13,5 @@ version = "1.4.1"
 libc = "0.2"
 
 [build-dependencies]
-bindgen = { version = "0.58", default-features = false }
+bindgen = { version = "0", default-features = false }
 cc = "1.0"


### PR DESCRIPTION
## `PeerDiff` updates

The previous `PeerDiff`'s diffing logic was less correct, given some optional fields for peers. It was also not well setup for getting debug output about what changed on the interface in each update.

This update hopefully adds some nicer visibility with the `-v` flag as well to show what changed about a peer.

## Endpoint updates

The past behavior of clients was to, on every fetch from the server, update each of its peer's endpoints with the one reported from the server. While this wasn't a problem on certain types of NATs to help with holepunching, in some situations it caused previously working connections to no longer work (when one peer had a port-restricted or symmetric cone type NAT).

The new proposed behavior would be to use the same indicator of connection currentness (a handshake within the last 180 seconds, a constant used by WireGuard as a boundary for a handshake no longer being usable for communication) to decide whether the peer's endpoint *needs* updating. If there has been a handshake with the peer being updated within the last 180 seconds, innernet will no longer change the endpoint for that peer.