### PR TITLE
Fix clippy warnings, add clippy to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,3 +47,8 @@ jobs:
       with:
         command: test
         args: --verbose
+    - name: Clippy
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+        args: -- -D warnings

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -510,7 +510,7 @@ fn fetch(
         if peers.iter().any(|p| p.public_key == public_key) {
             None
         } else {
-            PeerDiff::new(Some(&existing), None).unwrap()
+            PeerDiff::new(Some(existing), None).unwrap()
         }
     });
 

--- a/server/src/api/user.rs
+++ b/server/src/api/user.rs
@@ -162,7 +162,7 @@ mod tests {
         let whole_body = hyper::body::aggregate(res).await?;
         let State { peers, .. } = serde_json::from_reader(whole_body.reader())?;
         let mut peer_names = peers.iter().map(|p| &*p.contents.name).collect::<Vec<_>>();
-        peer_names.sort();
+        peer_names.sort_unstable();
         // Developers should see only peers in infra CIDR and developer CIDR.
         assert_eq!(
             &["developer1", "developer2", "innernet-server"],
@@ -284,7 +284,7 @@ mod tests {
             let whole_body = hyper::body::aggregate(res).await?;
             let State { peers, .. } = serde_json::from_reader(whole_body.reader())?;
             let mut peer_names = peers.iter().map(|p| &*p.contents.name).collect::<Vec<_>>();
-            peer_names.sort();
+            peer_names.sort_unstable();
             // Developers should see only peers in infra CIDR and developer CIDR.
             assert_eq!(
                 &[

--- a/server/src/test.rs
+++ b/server/src/test.rs
@@ -134,7 +134,7 @@ impl Server {
     pub fn context(&self) -> Context {
         Context {
             db: self.db.clone(),
-            interface: self.interface.clone(),
+            interface: self.interface,
             endpoints: self.endpoints.clone(),
             public_key: self.public_key.clone(),
             #[cfg(target_os = "linux")]

--- a/shared/src/types.rs
+++ b/shared/src/types.rs
@@ -511,7 +511,7 @@ impl<'a> PeerDiff<'a> {
     }
 
     pub fn public_key(&self) -> &Key {
-        &self.builder.public_key()
+        self.builder.public_key()
     }
 
     pub fn changes(&self) -> &[ChangeString] {


### PR DESCRIPTION
#### Tidy code a bit thanks to clippy

Clippy 1.54 newly detects some redundant constructs, that's nice.

sort_unstable() should yield exact same results as sort() for `Vec<&str>`
and could be faster, clippy says.

#### Add clippy to CI