### PR TITLE
Add "wireguard" as a recommended dependency for Debian.

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -44,6 +44,7 @@ assets = [
   ["../doc/innernet.completions.zsh", "usr/share/zsh/site-functions/_innernet", "644"],
 ]
 depends = "libc6, libgcc1, systemd"
+recommends = "wireguard"
 extended-description = "innernet client binary for fetching peer information and conducting admin tasks such as adding a new peer."
 maintainer = "tonari <hey@tonari.no>"
 name = "innernet"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -59,6 +59,7 @@ assets = [
   ["../doc/innernet-server.completions.fish", "usr/share/fish/vendor_completions.d/innernet-server.fish", "644"],
 ]
 depends = "libc6, libgcc1, libsqlite3-0, zlib1g, systemd"
+recommends = "wireguard"
 maintainer = "tonari <hey@tonari.no>"
 name = "innernet-server"
 priority = "optional"


### PR DESCRIPTION
It's very likely a user will want at least wireguard-dkms, and having
the userspace tools might be useful in an emergency. This metapackage
draws in both.

For automated installations in e.g. containers, use

    apt install --no-install-recommends

to avoid installing recommended packages.

I set up an auto-update APT repository on GitHub Pages for your deb files: https://github.com/tommie/innernet-debian