### PR TITLE
feat: add INNERNET_NAT_EXCLUDE_CIDR env variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,7 @@ dependencies = [
  "ipnetwork",
  "lazy_static",
  "log",
+ "netaddr2",
  "regex",
  "serde",
  "serde_json",
@@ -600,6 +601,12 @@ checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "netaddr2"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c786be7ab83e700aaf56af5f1e4b16247182446a7679fe43a4c0eaae31242180"
 
 [[package]]
 name = "netlink-packet-core"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -29,6 +29,7 @@ shared = { path = "../shared", default-features = false }
 structopt = "0.3"
 ureq = { version = "2", default-features = false, features = ["json"] }
 wireguard-control = { path = "../wireguard-control" }
+netaddr2 = "0.7.1"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
This comes in handy when nodes can talk to each other on multiple interfaces (eg. in a k8s cluster), but only some of them should be used for the innernet connection.