### PR TITLE
Drop short symlink to binary

### DIFF
--- a/client/.rpm/innernet.spec
+++ b/client/.rpm/innernet.spec
@@ -23,7 +23,6 @@ Requires: libgcc
 %setup -q
 
 %build
-ln -s %{name} .%{_bindir}/inn
 
 %install
 rm -rf %{buildroot}

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -37,7 +37,6 @@ tempfile = "3"
 [package.metadata.deb]
 assets = [
   ["target/release/innernet", "usr/bin/", "755"],
-  ["target/release/innernet", "usr/bin/inn", "755"],
   ["innernet@.service", "usr/lib/systemd/system/", "644"],
   ["../doc/innernet.8.gz", "usr/share/man/man8/", "644"],
   ["../doc/innernet.completions.bash", "etc/bash_completion.d/innernet", "644"],


### PR DESCRIPTION
I am a relative newcomer to this project, but just deployed it across a couple dozen devices on three continents. Remarkably I only ran into a handful of issues, and for most of those I see open issues for either fixing or documenting them. The most frustrating part of getting started was the confusing perceived lack of documentation. It turns out a lot of that was just a missmatch between the actual code and installations and the readme. The readme and **some** installations were referencing the client as `inn`, but others only had `innernet`. It took me quite a while to figure out that the short one was just a symlink to the full binary name and that I could safely ignore it.

As a long time sys admin and Linux packager (current Arch Linux TU, once PLD Linux core team member, etc.) I would like to suggest that this arrangement is *trouble* and should be dropped.

* It is difficult to package consistently. Especially for a Rust project without a real application build system (cargo handles the binary build fine but is not equivalent of autotools or cmake or meson or similar for full installs). Some systems (as I ran into) will not end up with the symlink at all. Even `cargo install` directly from crates.io is an example of an install that won't support that properly.

* It just makes a mess of documentation. Man pages are not accessible as `man inn`, and `inn --help` identifies as something other than the $0 as entered.

* Getting shell completion routines setup is just that much extra mess, and again not all distros are going to even end up with the symlink variant working right.

* Some systems won't support symlinks at all. Windows is going to require different shenanigans, Android is going to pose it's own problems with symlinks, etc. Just save people the trouble starting now and use the full `innernet` and only expect that one binarry.

There is nothing wrong with short alliases, but for Unix users these should be setup *by the end user* as `alias inn=innernet`. This will automatically take care of completions for most shells and has lots of other advantages, notably for documentation across platforms being consistent but people that type it a lot can still get a short command name.
