### PR TITLE
client, server systemd units: make Restart=always truly respected

### DIFF
--- a/client/innernet@.service
+++ b/client/innernet@.service
@@ -3,17 +3,15 @@ Description=innernet client daemon for %I
 After=network-online.target nss-lookup.target
 Wants=network-online.target nss-lookup.target
 PartOf=innernet.target
-# Disable systemd's unit start rate limiting logic, which could override Restart=always.
-# See https://unix.stackexchange.com/q/289629/352972
-StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 ExecStart=/usr/bin/innernet up %i --daemon --interval 60
 Restart=always
-# When the daemon exits, wait this amount of secs before restarting. Prevents innernet from
-# start-looping each 100ms for example when there is a problem reaching the server.
-RestartSec=60
+# When the daemon exits, wait this amount of secs before restarting. Used to prevent StartLimitBurst
+# (5 by default) restarts happening within StartLimitIntervalSec (10 by default) after which systemd
+# would refrain from restarting innernet anymore.
+RestartSec=10
 
 [Install]
 WantedBy=multi-user.target

--- a/client/innernet@.service
+++ b/client/innernet@.service
@@ -3,11 +3,17 @@ Description=innernet client daemon for %I
 After=network-online.target nss-lookup.target
 Wants=network-online.target nss-lookup.target
 PartOf=innernet.target
+# Disable systemd's unit start rate limiting logic, which could override Restart=always.
+# See https://unix.stackexchange.com/q/289629/352972
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 ExecStart=/usr/bin/innernet up %i --daemon --interval 60
 Restart=always
+# When the daemon exits, wait this amount of secs before restarting. Prevents innernet from
+# start-looping each 100ms for example when there is a problem reaching the server.
+RestartSec=60
 
 [Install]
 WantedBy=multi-user.target

--- a/server/innernet-server@.service
+++ b/server/innernet-server@.service
@@ -2,18 +2,14 @@
 Description=innernet server for %I
 After=network-online.target nss-lookup.target
 Wants=network-online.target nss-lookup.target
-# Disable systemd's unit start rate limiting logic, which could override Restart=always.
-# See https://unix.stackexchange.com/q/289629/352972
-StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 Environment="RUST_LOG=info"
 ExecStart=/usr/bin/innernet-server serve %i
 Restart=always
-# When the daemon exits, wait this amount of secs before restarting. Prevents innernet from
-# start-looping each 100ms for example when there is a problem reaching the server.
-RestartSec=60
+# When the daemon exits, wait this amount of secs before restarting instead of default 100ms.
+RestartSec=1
 
 [Install]
 WantedBy=multi-user.target

--- a/server/innernet-server@.service
+++ b/server/innernet-server@.service
@@ -2,12 +2,18 @@
 Description=innernet server for %I
 After=network-online.target nss-lookup.target
 Wants=network-online.target nss-lookup.target
+# Disable systemd's unit start rate limiting logic, which could override Restart=always.
+# See https://unix.stackexchange.com/q/289629/352972
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 Environment="RUST_LOG=info"
 ExecStart=/usr/bin/innernet-server serve %i
 Restart=always
+# When the daemon exits, wait this amount of secs before restarting. Prevents innernet from
+# start-looping each 100ms for example when there is a problem reaching the server.
+RestartSec=60
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Surprisingly, Restart=always may not _always_ restart the unit if it restarts too fast.

Set a combination of options which should make systemd truly restart innernet always.
See https://unix.stackexchange.com/q/289629/352972.

The `RestartSec=60` is the main and important one which would prevent systemd from ever failing
to restart innernet in the default settings (because with it it would never exceed the default
limit of 5 restarts in 10 seconds).

`StartLimitIntervalSec=0` option is a complementary one for explicitly disabling the logic, and
may be removed from this PR if deemed unnecessary.

Should fix tonarino/portal#1441 (link to issue in private repository).

---

I've tested this successfully with the client unit file (on an artificial problem though):
<details>

```
led 06 17:55:07 mat480s systemd[1]: Started innernet client daemon for tonari.
led 06 17:55:07 mat480s systemd[693653]: innernet@tonari.service: Failed to locate executable /usr/bin/innernet: No such file or directory
led 06 17:55:07 mat480s systemd[693653]: innernet@tonari.service: Failed at step EXEC spawning /usr/bin/innernet: No such file or directory
led 06 17:55:07 mat480s systemd[1]: innernet@tonari.service: Main process exited, code=exited, status=203/EXEC
led 06 17:55:07 mat480s systemd[1]: innernet@tonari.service: Failed with result 'exit-code'.


led 06 17:56:07 mat480s systemd[1]: innernet@tonari.service: Scheduled restart job, restart counter is at 1.
led 06 17:56:07 mat480s systemd[1]: Stopped innernet client daemon for tonari.
led 06 17:56:07 mat480s systemd[1]: Started innernet client daemon for tonari.
led 06 17:56:07 mat480s systemd[693719]: innernet@tonari.service: Failed to locate executable /usr/bin/innernet: No such file or directory
led 06 17:56:07 mat480s systemd[693719]: innernet@tonari.service: Failed at step EXEC spawning /usr/bin/innernet: No such file or directory
led 06 17:56:07 mat480s systemd[1]: innernet@tonari.service: Main process exited, code=exited, status=203/EXEC
led 06 17:56:07 mat480s systemd[1]: innernet@tonari.service: Failed with result 'exit-code'.

led 06 17:57:07 mat480s systemd[1]: innernet@tonari.service: Scheduled restart job, restart counter is at 2.
led 06 17:57:07 mat480s systemd[1]: Stopped innernet client daemon for tonari.
led 06 17:57:07 mat480s systemd[1]: Started innernet client daemon for tonari.
led 06 17:57:07 mat480s systemd[693733]: innernet@tonari.service: Failed to locate executable /usr/bin/innernet: No such file or directory
led 06 17:57:07 mat480s systemd[693733]: innernet@tonari.service: Failed at step EXEC spawning /usr/bin/innernet: No such file or directory
led 06 17:57:07 mat480s systemd[1]: innernet@tonari.service: Main process exited, code=exited, status=203/EXEC
led 06 17:57:07 mat480s systemd[1]: innernet@tonari.service: Failed with result 'exit-code'.


led 06 17:58:08 mat480s systemd[1]: innernet@tonari.service: Scheduled restart job, restart counter is at 3.
led 06 17:58:08 mat480s systemd[1]: Stopped innernet client daemon for tonari.
led 06 17:58:08 mat480s systemd[1]: Started innernet client daemon for tonari.
led 06 17:58:08 mat480s systemd[693820]: innernet@tonari.service: Failed to locate executable /usr/bin/innernet: No such file or directory
led 06 17:58:08 mat480s systemd[693820]: innernet@tonari.service: Failed at step EXEC spawning /usr/bin/innernet: No such file or directory
led 06 17:58:08 mat480s systemd[1]: innernet@tonari.service: Main process exited, code=exited, status=203/EXEC
led 06 17:58:08 mat480s systemd[1]: innernet@tonari.service: Failed with result 'exit-code'.
led 06 17:59:08 mat480s systemd[1]: innernet@tonari.service: Scheduled restart job, restart counter is at 4.
led 06 17:59:08 mat480s systemd[1]: Stopped innernet client daemon for tonari.
led 06 17:59:08 mat480s systemd[1]: Started innernet client daemon for tonari.
led 06 17:59:08 mat480s systemd[693865]: innernet@tonari.service: Failed to locate executable /usr/bin/innernet: No such file or directory
led 06 17:59:08 mat480s systemd[693865]: innernet@tonari.service: Failed at step EXEC spawning /usr/bin/innernet: No such file or directory
led 06 17:59:08 mat480s systemd[1]: innernet@tonari.service: Main process exited, code=exited, status=203/EXEC
led 06 17:59:08 mat480s systemd[1]: innernet@tonari.service: Failed with result 'exit-code'.


led 06 18:00:08 mat480s systemd[1]: innernet@tonari.service: Scheduled restart job, restart counter is at 5.
led 06 18:00:08 mat480s systemd[1]: Stopped innernet client daemon for tonari.
led 06 18:00:08 mat480s systemd[1]: Started innernet client daemon for tonari.
led 06 18:00:08 mat480s systemd[1]: innernet@tonari.service: Main process exited, code=exited, status=203/EXEC
led 06 18:00:08 mat480s systemd[1]: innernet@tonari.service: Failed with result 'exit-code'.



led 06 18:01:08 mat480s systemd[1]: innernet@tonari.service: Scheduled restart job, restart counter is at 6.
led 06 18:01:08 mat480s systemd[1]: Stopped innernet client daemon for tonari.
led 06 18:01:08 mat480s systemd[1]: Started innernet client daemon for tonari.
led 06 18:01:08 mat480s systemd[693907]: innernet@tonari.service: Failed to locate executable /usr/bin/innernet: No such file or directory
led 06 18:01:08 mat480s systemd[693907]: innernet@tonari.service: Failed at step EXEC spawning /usr/bin/innernet: No such file or directory
led 06 18:01:08 mat480s systemd[1]: innernet@tonari.service: Main process exited, code=exited, status=203/EXEC
led 06 18:01:08 mat480s systemd[1]: innernet@tonari.service: Failed with result 'exit-code'.


led 06 18:02:09 mat480s systemd[1]: innernet@tonari.service: Scheduled restart job, restart counter is at 7.
led 06 18:02:09 mat480s systemd[1]: Stopped innernet client daemon for tonari.
led 06 18:02:09 mat480s systemd[1]: Started innernet client daemon for tonari.
led 06 18:02:09 mat480s systemd[693935]: innernet@tonari.service: Failed to locate executable /usr/bin/innernet: No such file or directory
led 06 18:02:09 mat480s systemd[693935]: innernet@tonari.service: Failed at step EXEC spawning /usr/bin/innernet: No such file or directory
led 06 18:02:09 mat480s systemd[1]: innernet@tonari.service: Main process exited, code=exited, status=203/EXEC
led 06 18:02:09 mat480s systemd[1]: innernet@tonari.service: Failed with result 'exit-code'.

led 06 18:03:09 mat480s systemd[1]: innernet@tonari.service: Scheduled restart job, restart counter is at 8.
led 06 18:03:09 mat480s systemd[1]: Stopped innernet client daemon for tonari.
led 06 18:03:09 mat480s systemd[1]: Started innernet client daemon for tonari.
led 06 18:03:09 mat480s systemd[694037]: innernet@tonari.service: Failed to locate executable /usr/bin/innernet: No such file or directory
led 06 18:03:09 mat480s systemd[694037]: innernet@tonari.service: Failed at step EXEC spawning /usr/bin/innernet: No such file or directory
led 06 18:03:09 mat480s systemd[1]: innernet@tonari.service: Main process exited, code=exited, status=203/EXEC
led 06 18:03:09 mat480s systemd[1]: innernet@tonari.service: Failed with result 'exit-code'.
```
</details>