### PR TITLE
hostsfile: safely overwrite hosts file instead of clobbering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,7 +358,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hostsfile"
-version = "1.1.0"
+version = "1.2.0"
 
 [[package]]
 name = "http"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,6 +359,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hostsfile"
 version = "1.2.0"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "http"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,6 +361,7 @@ name = "hostsfile"
 version = "1.2.0"
 dependencies = [
  "log",
+ "tempfile",
 ]
 
 [[package]]

--- a/hostsfile/Cargo.toml
+++ b/hostsfile/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 license = "UNLICENSED"
 name = "hostsfile"
 publish = false
-version = "1.1.0"
+version = "1.2.0"
 
 [dependencies]

--- a/hostsfile/Cargo.toml
+++ b/hostsfile/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Ryo Kawaguchi <ryo@kawagu.ch>"]
 description = "A simplistic /etc/hosts file editor."
 edition = "2021"
-license = "UNLICENSED"
+license = "MIT"
 name = "hostsfile"
 publish = false
 version = "1.2.0"

--- a/hostsfile/Cargo.toml
+++ b/hostsfile/Cargo.toml
@@ -9,3 +9,6 @@ version = "1.2.0"
 
 [dependencies]
 log = "0.4"
+
+[dev-dependencies]
+tempfile = "3"

--- a/hostsfile/Cargo.toml
+++ b/hostsfile/Cargo.toml
@@ -8,3 +8,4 @@ publish = false
 version = "1.2.0"
 
 [dependencies]
+log = "0.4"

--- a/hostsfile/src/lib.rs
+++ b/hostsfile/src/lib.rs
@@ -253,8 +253,14 @@ impl HostsBuilder {
         }
 
         match Self::write_and_swap(&temp_path, &hosts_path, &s) {
-            Err(_) => Self::write_clobber(&hosts_path, &s),
-            _ => Ok(()),
+            Err(_) => {
+                log::debug!("wrote hosts file with the clobber fallback strategy");
+                Self::write_clobber(&hosts_path, &s)
+            },
+            _ => {
+                log::debug!("wrote hosts file with the write-and-swap strategy");
+                Ok(())
+            }
         }
     }
 

--- a/hostsfile/src/lib.rs
+++ b/hostsfile/src/lib.rs
@@ -265,6 +265,7 @@ impl HostsBuilder {
     }
 
     fn write_and_swap(temp_path: &Path, hosts_path: &Path, contents: &[u8]) -> io::Result<()> {
+        // Copy the file we plan on modifying so its permissions and metadata are preserved.
         std::fs::copy(&hosts_path, &temp_path)?;
         Self::write_clobber(temp_path, contents)?;
         std::fs::rename(temp_path, hosts_path)?;

--- a/hostsfile/src/lib.rs
+++ b/hostsfile/src/lib.rs
@@ -252,15 +252,15 @@ impl HostsBuilder {
             writeln!(&mut s, "{}", line)?;
         }
 
-        match Self::write_and_swap(&temp_path, &hosts_path, &s) {
+        match Self::write_and_swap(&temp_path, hosts_path, &s) {
             Err(_) => {
                 log::debug!("wrote hosts file with the clobber fallback strategy");
-                Self::write_clobber(&hosts_path, &s)
+                Self::write_clobber(hosts_path, &s)
             },
             _ => {
                 log::debug!("wrote hosts file with the write-and-swap strategy");
                 Ok(())
-            }
+            },
         }
     }
 
@@ -272,7 +272,7 @@ impl HostsBuilder {
             .write(true)
             .truncate(true)
             .open(&temp_path)?
-            .write_all(&contents)?;
+            .write_all(contents)?;
 
         std::fs::rename(temp_path, hosts_path)?;
         Ok(())
@@ -285,7 +285,7 @@ impl HostsBuilder {
             .write(true)
             .truncate(true)
             .open(hosts_path)?
-            .write_all(&contents)?;
+            .write_all(contents)?;
         Ok(())
     }
 }

--- a/hostsfile/src/lib.rs
+++ b/hostsfile/src/lib.rs
@@ -313,4 +313,19 @@ mod tests {
         let hosts_path = Path::new("/");
         assert!(HostsBuilder::get_temp_path(hosts_path).is_err());
     }
+
+    #[test]
+    fn test_write() {
+        let (mut temp_file, temp_path) = tempfile::NamedTempFile::new().unwrap().into_parts();
+        temp_file.write_all(b"preexisting\ncontent").unwrap();
+        let mut builder = HostsBuilder::new("foo");
+        builder.add_hostname([1, 1, 1, 1].into(), "whatever");
+        builder.write_to(&temp_path).unwrap();
+
+        let contents = std::fs::read_to_string(&temp_path).unwrap();
+        println!("contents: {}", contents);
+        assert!(contents.starts_with("preexisting\ncontent"));
+        assert!(contents.contains("# DO NOT EDIT foo BEGIN"));
+        assert!(contents.contains("1.1.1.1 whatever"));
+    }
 }

--- a/hostsfile/src/lib.rs
+++ b/hostsfile/src/lib.rs
@@ -254,14 +254,14 @@ impl HostsBuilder {
 
         match Self::write_and_swap(&temp_path, hosts_path, &s) {
             Err(_) => {
+                Self::write_clobber(hosts_path, &s)?;
                 log::debug!("wrote hosts file with the clobber fallback strategy");
-                Self::write_clobber(hosts_path, &s)
             },
             _ => {
                 log::debug!("wrote hosts file with the write-and-swap strategy");
-                Ok(())
             },
         }
+        Ok(())
     }
 
     fn write_and_swap(temp_path: &Path, hosts_path: &Path, contents: &[u8]) -> io::Result<()> {

--- a/hostsfile/src/lib.rs
+++ b/hostsfile/src/lib.rs
@@ -266,14 +266,7 @@ impl HostsBuilder {
 
     fn write_and_swap(temp_path: &Path, hosts_path: &Path, contents: &[u8]) -> io::Result<()> {
         std::fs::copy(&hosts_path, &temp_path)?;
-        OpenOptions::new()
-            .create(false)
-            .read(true)
-            .write(true)
-            .truncate(true)
-            .open(&temp_path)?
-            .write_all(contents)?;
-
+        Self::write_clobber(temp_path, contents)?;
         std::fs::rename(temp_path, hosts_path)?;
         Ok(())
     }

--- a/hostsfile/src/lib.rs
+++ b/hostsfile/src/lib.rs
@@ -5,7 +5,8 @@ use std::{
     io::{self, BufRead, BufReader, ErrorKind, Write},
     net::IpAddr,
     path::{Path, PathBuf},
-    result, time::{SystemTime, UNIX_EPOCH},
+    result,
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 pub type Result<T> = result::Result<T, Box<dyn std::error::Error>>;
@@ -149,9 +150,30 @@ impl HostsBuilder {
         Ok(hosts_file)
     }
 
+    pub fn get_temp_path(hosts_path: &Path) -> io::Result<PathBuf> {
+        let hosts_dir = hosts_path.parent().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "hosts path missing a parent folder",
+            )
+        })?;
+        let start = SystemTime::now();
+        let since_the_epoch = start
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards");
+        let mut temp_filename = hosts_path
+            .file_name()
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidInput, "hosts path missing a filename")
+            })?
+            .to_os_string();
+        temp_filename.push(format!(".tmp{}", since_the_epoch.as_millis()));
+        Ok(hosts_dir.with_file_name(temp_filename))
+    }
+
     /// Inserts a new section to the specified hosts file.  If there is a section with the same tag
     /// name already, it will be replaced with the new list instead.
-    /// 
+    ///
     /// `hosts_path` is the *full* path to write to, including the filename.
     ///
     /// On Windows, the format of one hostname per line will be used, all other systems will use
@@ -160,20 +182,13 @@ impl HostsBuilder {
         let hosts_path = hosts_path.as_ref();
         if hosts_path.is_dir() {
             // TODO(jake): use io::ErrorKind::IsADirectory when it's stable.
-            return Err(io::Error::new(io::ErrorKind::InvalidInput, "hosts path was a directory"));
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "hosts path was a directory",
+            ));
         }
-        let hosts_dir = hosts_path.parent()
-            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "hosts path missing a parent folder"))?;
 
-        let start = SystemTime::now();
-        let since_the_epoch = start
-            .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards");
-        let mut temp_filename = hosts_path.file_name()
-            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "hosts path missing a filename"))?
-            .to_os_string();
-        temp_filename.push(format!(".tmp{}", since_the_epoch.as_millis()));
-        let temp_path = hosts_dir.with_file_name(temp_filename);
+        let temp_path = Self::get_temp_path(hosts_path)?;
 
         let begin_marker = format!("# DO NOT EDIT {} BEGIN", &self.tag);
         let end_marker = format!("# DO NOT EDIT {} END", &self.tag);
@@ -248,5 +263,30 @@ impl HostsBuilder {
         std::fs::rename(temp_path, hosts_path)?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn test_temp_path_good() {
+        let hosts_path = Path::new("/etc/hosts");
+        let temp_path = HostsBuilder::get_temp_path(hosts_path).unwrap();
+        println!("{:?}", temp_path);
+        assert!(temp_path
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .starts_with("hosts.tmp"));
+    }
+
+    #[test]
+    fn test_temp_path_invalid() {
+        let hosts_path = Path::new("/");
+        assert!(HostsBuilder::get_temp_path(hosts_path).is_err());
     }
 }


### PR DESCRIPTION
In this case, I just opted to use a millisecond timestamp instead of a random number to avoid extra dependencies.

fixes #183