### PR TITLE
enable IPv6 NAT candidate reporting

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -602,10 +602,13 @@ fn fetch(
         .map(|addr| SocketAddr::from((addr, device.listen_port.unwrap_or(51820))).into())
         .collect::<Vec<Endpoint>>();
     log::info!(
-        "reporting {} interface address{} as NAT traversal candidates...",
+        "reporting {} interface address{} as NAT traversal candidates",
         candidates.len(),
-        if candidates.len() == 1 { "" } else { "es" }
+        if candidates.len() == 1 { "" } else { "es" },
     );
+    for candidate in &candidates {
+        log::debug!("  candidate: {}", candidate);
+    }
     match api.http_form::<_, ()>("PUT", "/user/candidates", &candidates) {
         Err(ureq::Error::Status(404, _)) => {
             log::warn!("your network is using an old version of innernet-server that doesn't support NAT traversal candidate reporting.")

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -99,7 +99,7 @@ pub use netlink::get_local_addrs as _get_local_addrs;
 
 pub fn get_local_addrs() -> Result<impl Iterator<Item = std::net::IpAddr>, io::Error> {
     // TODO(jake): this is temporary pending the stabilization of rust-lang/rust#27709
-    fn is_unicast_global(ip: Ipv6Addr) -> bool {
+    fn is_unicast_global(ip: &Ipv6Addr) -> bool {
         !((ip.segments()[0] & 0xff00) == 0xff00 // multicast
             || ip.is_loopback()
             || ip.is_unspecified()
@@ -112,7 +112,7 @@ pub fn get_local_addrs() -> Result<impl Iterator<Item = std::net::IpAddr>, io::E
         .filter(|ip| {
             ip.is_ipv4()
                 || matches!(ip,
-            IpAddr::V6(v6) if is_unicast_global(*v6))
+            IpAddr::V6(v6) if is_unicast_global(v6))
         })
         .take(10))
 }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -75,8 +75,6 @@ pub fn chmod(file: &File, new_mode: u32) -> Result<bool, io::Error> {
 
 #[cfg(target_os = "macos")]
 pub fn _get_local_addrs() -> Result<impl Iterator<Item = std::net::IpAddr>, io::Error> {
-    use std::net::IpAddr;
-
     use nix::{net::if_::InterfaceFlags, sys::socket::SockAddr};
 
     let addrs = nix::ifaddrs::getifaddrs()?

--- a/shared/src/netlink.rs
+++ b/shared/src/netlink.rs
@@ -159,7 +159,10 @@ pub fn get_local_addrs() -> Result<impl Iterator<Item = IpAddr>, io::Error> {
                 None
             })
         // Only select addresses for helpful links
-        .filter(move |nlas| nlas.iter().any(|nla| matches!(nla, address::nlas::Nla::Label(label) if links.contains(label))))
+        .filter(move |nlas| nlas.iter().any(|nla| {
+            matches!(nla, address::nlas::Nla::Label(label) if links.contains(label))
+            || matches!(nla, address::nlas::Nla::Address(name) if name.len() == 16)
+        }))
         .filter_map(|nlas| nlas.iter().find_map(|nla| match nla {
             address::nlas::Nla::Address(name) if name.len() == 4 => {
                 let mut addr = [0u8; 4];


### PR DESCRIPTION
This comes from the conversation in #191

**previous behavior**: filter out all IPv6 addresses from being reported as NAT candidates.

**new behavior**: Begin reporting IPv6 addresses that are *global unicast* scope only.

An argument could be made for also reporting [unique local addresses](https://en.wikipedia.org/wiki/Unique_local_address) as well, but I think it's less important and more likely to increase noise with little benefit to getting through any different types of NATs.

I'd love to hear from people more experienced with managing IPv6 addresses if that's not an appropriate strategy.