### PR TITLE
client: re-attempt NAT traversal on all unconnected peers

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -616,7 +616,7 @@ fn fetch(
         Err(e) => return Err(e.into()),
         _ => {},
     }
-    log::debug!("reported candidates: {:?}", candidates);
+    log::debug!("candidates successfully reported");
 
     if nat.no_nat_traversal {
         log::debug!("NAT traversal explicitly disabled, not attempting.");

--- a/shared/src/types.rs
+++ b/shared/src/types.rs
@@ -648,6 +648,7 @@ impl<'a> PeerDiff<'a> {
             .map(|info| info.is_recently_connected())
             .unwrap_or_default()
         {
+            let mut endpoint_changed = false;
             let resolved = new.endpoint.as_ref().and_then(|e| e.resolve().ok());
             if let Some(addr) = resolved {
                 if old.is_none() || matches!(old, Some(old) if old.endpoint != resolved) {
@@ -657,9 +658,18 @@ impl<'a> PeerDiff<'a> {
                         old.and_then(|p| p.endpoint),
                         Some(addr),
                     ));
+                    endpoint_changed = true;
                 }
             }
+            if !endpoint_changed && !new.candidates.is_empty() {
+                changes.push(ChangeString::new(
+                    "Connection status",
+                    "Disconnected".into(),
+                    "NAT traverse reattempt".into(),
+                ));
+            }
         }
+
         if !changes.is_empty() {
             Some((builder, changes))
         } else {


### PR DESCRIPTION
fixes #173