### PR TITLE
External endpoint IP prompt change

### DIFF
--- a/shared/src/prompts.rs
+++ b/shared/src/prompts.rs
@@ -508,7 +508,7 @@ pub fn ask_endpoint(listen_port: u16) -> Result<Endpoint, Error> {
 
     let external_ip = if Confirm::with_theme(&*THEME)
         .wait_for_newline(true)
-        .with_prompt("Auto-fill public IP address (via a DNS query to 1.1.1.1)?")
+        .with_prompt("Auto-detect external endpoint IP address (via a DNS query to 1.1.1.1)?")
         .interact()?
     {
         publicip::get_any(Preference::Ipv4)

--- a/shared/src/prompts.rs
+++ b/shared/src/prompts.rs
@@ -504,8 +504,6 @@ pub fn set_listen_port(
 }
 
 pub fn ask_endpoint(listen_port: u16) -> Result<Endpoint, Error> {
-    println!("getting external IP address.");
-
     let external_ip = if Confirm::with_theme(&*THEME)
         .wait_for_newline(true)
         .with_prompt("Auto-detect external endpoint IP address (via a DNS query to 1.1.1.1)?")


### PR DESCRIPTION
This changes the prompt for the external endpoint IP when creating a network. Specifically, it:

- Changes the "public IP address" to "external endpoint IP address" (as far as I see, the term "public IP" isn't used elsewhere in innernet)
- Changes "auto-fill" to "auto-detect"
- Removes an (apparently?) superfluous print

Small changes! But the existing prompt briefly confused me, so I thought it was worth the suggestion.