### PR TITLE
server: Implement disable-peer and enable-peer commands

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -827,7 +827,7 @@ fn enable_or_disable_peer(
         contents.is_disabled = !enable;
         api.http_form("PUT", &format!("/admin/peers/{}", id), contents)?;
     } else {
-        log::info!("exiting without disabling peer.");
+        log::info!("exiting without enabling or disabling peer.");
     }
 
     Ok(())

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -95,6 +95,12 @@ enum Command {
         args: AddPeerOpts,
     },
 
+    /// Disable an enabled peer
+    DisablePeer { interface: Interface },
+
+    /// Enable a disabled peer
+    EnablePeer { interface: Interface },
+
     /// Rename an existing peer.
     RenamePeer {
         interface: Interface,
@@ -264,6 +270,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         } => serve(*interface, &conf, routing).await?,
         Command::AddPeer { interface, args } => add_peer(&interface, &conf, args, opts.network)?,
         Command::RenamePeer { interface, args } => rename_peer(&interface, &conf, args)?,
+        Command::DisablePeer { interface } => enable_or_disable_peer(&interface, &conf, false)?,
+        Command::EnablePeer { interface } => enable_or_disable_peer(&interface, &conf, true)?,
         Command::AddCidr { interface, args } => add_cidr(&interface, &conf, args)?,
         Command::DeleteCidr { interface, args } => delete_cidr(&interface, &conf, args)?,
         Command::Completions { shell } => {
@@ -360,6 +368,33 @@ fn rename_peer(
         let _peer = db_peer.update(&conn, peer_request)?;
     } else {
         println!("exited without creating peer.");
+    }
+
+    Ok(())
+}
+
+fn enable_or_disable_peer(
+    interface: &InterfaceName,
+    conf: &ServerConfig,
+    enable: bool,
+) -> Result<(), Error> {
+    let conn = open_database_connection(interface, conf)?;
+    let peers = DatabasePeer::list(&conn)?
+        .into_iter()
+        .map(|dp| dp.inner)
+        .collect::<Vec<_>>();
+
+    if let Some(peer) = prompts::enable_or_disable_peer(&peers[..], enable)? {
+        let mut db_peer = DatabasePeer::get(&conn, peer.id)?;
+        db_peer.update(
+            &conn,
+            PeerContents {
+                is_disabled: !enable,
+                ..peer.contents.clone()
+            },
+        )?;
+    } else {
+        log::info!("exiting without enabling or disabling peer.");
     }
 
     Ok(())


### PR DESCRIPTION
This pull request implements enabling and disabling of peers directly accessing the server's database, as such not requiring non server admin peers.

The server will also apply changes to the wireguard interface immediately