### PR TITLE
avoid a rustc bug

### DIFF
--- a/shared/src/types.rs
+++ b/shared/src/types.rs
@@ -259,11 +259,11 @@ impl<'a> CidrTree<'a> {
         }
     }
 
-    pub fn children(&self) -> impl Iterator<Item = CidrTree> {
+    pub fn children(&self) -> impl Iterator<Item = CidrTree<'_>> {
         self.cidrs
             .iter()
             .filter(move |c| c.parent == Some(self.contents.id))
-            .map(move |c| Self {
+            .map(move |c| CidrTree {
                 cidrs: self.cidrs,
                 contents: c,
             })


### PR DESCRIPTION
Hi,

https://github.com/rust-lang/rust/pull/98835 fixes a rustc bug that makes it incorrectly accepts the following code:
```rust
fn test<'a: 'a>() { // 'a is longer than the entire function body
    let f = |_: &'a str| {}; // expects an argument that lives as long as 'a
    f(&String::new()); // the passed reference is shorter that `'a`
}
```

The crater run found that `innernet` will break with this change because it *indirectly* relies on this bug. I'm not sure when this change reaches stable, if ever, but it's better to not rely on such a bug. This PR tries to fix this.

If you have an opinion on this change, please let me know here or  by commenting on the PR.

You can install and test the toolchain locally by running the command: `rustup-toolchain-install-master cb1f7c96119295882e08b09b4bd01051669c071b`