### PR TITLE
fix(server): :bug: add bundled flag to rusqlite dependency on musl-libc

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -47,6 +47,9 @@ wireguard-control = { path = "../wireguard-control" }
 [target.'cfg(target_os = "linux")'.dependencies]
 socket2 = { version = "0.4", features = ["all"] }
 
+[target.'cfg(target_env = "musl")'.dependencies]
+rusqlite = { version = "0.28", features = ["bundled"] }
+
 [dev-dependencies]
 anyhow = "1"
 tempfile = "3"


### PR DESCRIPTION
fix(server): :bug: add bundled flag to rusqlite dependency on musl-libc target

- fixes #228
- the musl libc is used on Alpine, a minimal linux distribution commonly
  used in docker images. It's also used on OpenWRT which might be of
  interest to innernet.