### PR TITLE
CI: use stable clippy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,7 @@ jobs:
         command: test
         args: --features v6-test --verbose
 
-  fmt-and-clippy:
+  fmt:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -56,12 +56,23 @@ jobs:
         profile: minimal
         toolchain: nightly
         override: true
-        components: rustfmt, clippy
+        components: rustfmt
     - name: Rustfmt
       uses: actions-rs/cargo@v1
       with:
         command: fmt
         args: --all -- --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+        components: clippy
     - name: Clippy
       uses: actions-rs/cargo@v1
       with:


### PR DESCRIPTION
Using nightly one leads to having to resolve lints more frequently than rust releases, which is getting inconvenient.

It also leads to a small compatibility issue with stable clippy: if we need to #[allow] a lint that is only present in nightly clippy, then stable clippy complains about unknown lint in the `allow`. :shrug: 