### PR TITLE
cargo clippy --fix --all-targets (clippy 1.66)

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install Dependencies
       env:
         ACCEPT_EULA: Y
-      run: sudo apt-get -y update && sudo apt-get install -f && sudo apt-get -y install libsqlite3-dev libclang-9-dev
+      run: sudo apt-get -y update && sudo apt-get install -f && sudo apt-get -y install libsqlite3-dev libclang-11-dev
     - uses: Swatinem/rust-cache@v1
     - name: Build
       uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install Dependencies (if Ubuntu)
       env:
         ACCEPT_EULA: Y
-      run: sudo apt-get -y update && sudo apt-get install -f && sudo apt-get -y install libsqlite3-dev libclang-9-dev
+      run: sudo apt-get -y update && sudo apt-get install -f && sudo apt-get -y install libsqlite3-dev libclang-11-dev
       if: contains(runner.os, 'Linux')
     - uses: Swatinem/rust-cache@v1
     - name: Build

--- a/client/src/data_store.rs
+++ b/client/src/data_store.rs
@@ -174,7 +174,7 @@ mod tests {
     }
 
     fn setup_basic_store(dir: &Path) {
-        let mut store = DataStore::open_with_path(&dir.join("peer_store.json"), true).unwrap();
+        let mut store = DataStore::open_with_path(dir.join("peer_store.json"), true).unwrap();
 
         println!("{:?}", store);
         assert_eq!(0, store.peers().len());
@@ -189,7 +189,7 @@ mod tests {
     fn test_sanity() {
         let dir = tempfile::tempdir().unwrap();
         setup_basic_store(dir.path());
-        let store = DataStore::open_with_path(&dir.path().join("peer_store.json"), false).unwrap();
+        let store = DataStore::open_with_path(dir.path().join("peer_store.json"), false).unwrap();
         assert_eq!(store.peers(), &*BASE_PEERS);
         assert_eq!(store.cidrs(), &*BASE_CIDRS);
     }
@@ -199,7 +199,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         setup_basic_store(dir.path());
         let mut store =
-            DataStore::open_with_path(&dir.path().join("peer_store.json"), false).unwrap();
+            DataStore::open_with_path(dir.path().join("peer_store.json"), false).unwrap();
 
         // Should work, since peer is unmodified.
         store.update_peers(&BASE_PEERS).unwrap();
@@ -216,7 +216,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         setup_basic_store(dir.path());
         let mut store =
-            DataStore::open_with_path(&dir.path().join("peer_store.json"), false).unwrap();
+            DataStore::open_with_path(dir.path().join("peer_store.json"), false).unwrap();
 
         // Should work, since peer is unmodified.
         store.update_peers(&[]).unwrap();

--- a/hostsfile/src/lib.rs
+++ b/hostsfile/src/lib.rs
@@ -117,7 +117,7 @@ impl HostsBuilder {
     /// Inserts a new section to the system's default hosts file.  If there is a section with the
     /// same tag name already, it will be replaced with the new list instead.
     pub fn write(&self) -> io::Result<()> {
-        self.write_to(&Self::default_path()?)
+        self.write_to(Self::default_path()?)
     }
 
     /// Returns the default hosts path based on the current OS.

--- a/server/src/api/admin/association.rs
+++ b/server/src/api/admin/association.rs
@@ -49,7 +49,7 @@ mod handlers {
         let conn = session.context.db.lock();
         let auths = DatabaseAssociation::list(&conn)?;
 
-        json_response(&auths)
+        json_response(auths)
     }
 
     pub async fn delete(id: i64, session: Session) -> Result<Response<Body>, ServerError> {

--- a/server/src/api/admin/cidr.rs
+++ b/server/src/api/admin/cidr.rs
@@ -40,14 +40,14 @@ mod handlers {
 
         let cidr = DatabaseCidr::create(&conn, contents)?;
 
-        json_status_response(&cidr, StatusCode::CREATED)
+        json_status_response(cidr, StatusCode::CREATED)
     }
 
     pub async fn list(session: Session) -> Result<Response<Body>, ServerError> {
         let conn = session.context.db.lock();
         let cidrs = DatabaseCidr::list(&conn)?;
 
-        json_response(&cidrs)
+        json_response(cidrs)
     }
 
     pub async fn delete(id: i64, session: Session) -> Result<Response<Body>, ServerError> {

--- a/server/src/initialize.rs
+++ b/server/src/initialize.rs
@@ -178,7 +178,7 @@ pub fn init_wizard(conf: &ServerConfig, opts: InitializeOpts) -> Result<(), Erro
         address: our_ip,
         network_cidr_prefix: root_cidr.prefix_len(),
     };
-    config.write_to_path(&config_path)?;
+    config.write_to_path(config_path)?;
 
     let db_init_data = DbInitData {
         network_name: name.to_string(),

--- a/server/src/test.rs
+++ b/server/src/test.rs
@@ -103,7 +103,7 @@ impl Server {
 
         let interface = interface.parse().unwrap();
         // Add developer CIDR and user CIDR and some peers for testing.
-        let db = Connection::open(&conf.database_path(&interface))?;
+        let db = Connection::open(conf.database_path(&interface))?;
         db.pragma_update(None, "foreign_keys", 1)?;
         assert_eq!(ADMIN_CIDR_ID, create_cidr(&db, "admin", ADMIN_CIDR)?.id);
         assert_eq!(

--- a/wireguard-control/src/backends/userspace.rs
+++ b/wireguard-control/src/backends/userspace.rs
@@ -27,14 +27,14 @@ fn get_base_folder() -> io::Result<PathBuf> {
 }
 
 fn get_namefile(name: &InterfaceName) -> io::Result<PathBuf> {
-    Ok(get_base_folder()?.join(&format!("{}.name", name.as_str_lossy())))
+    Ok(get_base_folder()?.join(format!("{}.name", name.as_str_lossy())))
 }
 
 fn get_socketfile(name: &InterfaceName) -> io::Result<PathBuf> {
     if cfg!(target_os = "linux") {
-        Ok(get_base_folder()?.join(&format!("{}.sock", name)))
+        Ok(get_base_folder()?.join(format!("{}.sock", name)))
     } else {
-        Ok(get_base_folder()?.join(&format!("{}.sock", resolve_tun(name)?)))
+        Ok(get_base_folder()?.join(format!("{}.sock", resolve_tun(name)?)))
     }
 }
 
@@ -273,7 +273,7 @@ fn get_userspace_implementation() -> String {
 }
 
 fn start_userspace_wireguard(iface: &InterfaceName) -> io::Result<Output> {
-    let mut command = Command::new(&get_userspace_implementation());
+    let mut command = Command::new(get_userspace_implementation());
     let output = if cfg!(target_os = "linux") {
         command.args(&[iface.to_string()]).output()?
     } else {


### PR DESCRIPTION
This is exclusively (if I look correctly) redundant referencing.

### Update Ubuntu dependencies to fix CI
I was not sure what version to use as Ubuntu jammy has clang 11, 12, 13 and 14 (!). I stayed conservative.