### PR TITLE
Add `Actively Maintained` and `MIT` license badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # innernet
 
+[![Actively Maintained](https://img.shields.io/badge/Maintenance%20Level-Actively%20Maintained-green.svg)](https://gist.github.com/cheerfulstoic/d107229326a01ff0f333a1d3476e068d)
+[![MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/tonarino/innernet/blob/master/LICENSE)
+
 A private network system that uses [WireGuard](https://wireguard.com) under the hood. See the [announcement blog post](https://blog.tonari.no/introducing-innernet) for a longer-winded explanation.
 
 <img src="https://user-images.githubusercontent.com/373823/118917068-09ae7700-b96b-11eb-80f4-6860072d504d.gif" width="600" height="370">


### PR DESCRIPTION
The maintenance badge leads to https://gist.github.com/cheerfulstoic/d107229326a01ff0f333a1d3476e068d

_Actively Maintained_ is described there as
> The maintainer(s) of this project are responding to issues and integrating code contributions

...which should set the correct expectations for people stumbling upon the project. Not explicitly said, but I count that also means we'll be doing (minor, mostly) releases.

Compare that with
> _Actively Developed_
>The maintainer(s) of this project are currently writing code for this project as well as responding to issues and integrating code contributions 