### PR TITLE
Remove extraneous into_iter() (clippy 1.68 fix)

### DIFF
--- a/client/src/util.rs
+++ b/client/src/util.rs
@@ -172,9 +172,7 @@ pub fn print_peer_diff(store: &DataStore, diff: &PeerDiff) {
 
 pub fn all_installed(config_dir: &Path) -> Result<Vec<Interface>, std::io::Error> {
     // All errors are bubbled up when enumerating a directory
-    let entries: Vec<_> = std::fs::read_dir(config_dir)?
-        .into_iter()
-        .collect::<Result<_, _>>()?;
+    let entries: Vec<_> = std::fs::read_dir(config_dir)?.collect::<Result<_, _>>()?;
 
     let installed: Vec<_> = entries
         .into_iter()


### PR DESCRIPTION
https://doc.rust-lang.org/std/fs/fn.read_dir.html already returns an Iterator (`ReadDir`s IntoIter implementation returns `self`)

It looks like the only PRs I submit are clippy fixes, but I believe one day it will be something more interesting. :)