### PR TITLE
update release.toml for latest cargo-release compat

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -2,4 +2,3 @@ consolidate-commits = true
 publish = false
 push = false
 tag = false
-dev-version = false


### PR DESCRIPTION
`release.sh` script will fail otherwise. I honestly don't remember what `dev-version` was for, but a quick run of the script seems to do the right thing still.