### PR TITLE
#277 - add gcc, change dnf to yum

### DIFF
--- a/rpm/Dockerfile
+++ b/rpm/Dockerfile
@@ -4,8 +4,8 @@ ARG VER
 FROM ${DISTRO}:${VER} as builder
 LABEL stage=innernet-rpm
 
-RUN dnf -y update && \
-	dnf -y install clang-devel sqlite-devel glibc-devel rpm-build && \
+RUN yum -y update && \
+	yum -y install gcc clang-devel sqlite-devel glibc-devel rpm-build && \
 	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
 
 WORKDIR /workdir


### PR DESCRIPTION
* add the `gcc` package to the packages to add to the docker image for build
* change `dnf` to `yum`.  (systems that use `dnf` always have `yum` and the basic `yum/dnf` commands are identical)
* I have built packages for Fedora 37,38 and CentOS 7 with this fix applied