### PR TITLE
Fix docker tests

### DIFF
--- a/docker-tests/Dockerfile.innernet
+++ b/docker-tests/Dockerfile.innernet
@@ -1,7 +1,7 @@
 ####################################################################################################
 ## WireGuard
 ####################################################################################################
-FROM golang:latest as wireguard
+FROM golang:bookworm as wireguard
 ARG wg_go_tag=0.0.20230223
 ARG wg_tools_tag=v1.0.20210914
 
@@ -9,12 +9,12 @@ RUN mkdir /repo \
     && curl -L https://github.com/WireGuard/wireguard-go/archive/refs/tags/0.0.20230223.tar.gz \
     | tar -xzC /repo --strip-components=1 \
     && cd /repo \
-    && make
+    && CGO_ENABLED=0 make
 
 ####################################################################################################
 ## Final image
 ####################################################################################################
-FROM rust:slim
+FROM rust:slim-bookworm
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libsqlite3-dev iproute2 iputils-ping build-essential clang libclang-dev && \
     rm -rf /var/lib/apt/lists/*

--- a/docker-tests/Dockerfile.innernet
+++ b/docker-tests/Dockerfile.innernet
@@ -2,11 +2,11 @@
 ## WireGuard
 ####################################################################################################
 FROM golang:latest as wireguard
-ARG wg_go_tag=0.0.20210323
-ARG wg_tools_tag=v1.0.20210315
+ARG wg_go_tag=0.0.20230223
+ARG wg_tools_tag=v1.0.20210914
 
 RUN mkdir /repo \
-    && curl -L https://github.com/WireGuard/wireguard-go/archive/refs/tags/0.0.20210424.tar.gz \
+    && curl -L https://github.com/WireGuard/wireguard-go/archive/refs/tags/0.0.20230223.tar.gz \
     | tar -xzC /repo --strip-components=1 \
     && cd /repo \
     && make

--- a/docker-tests/run-docker-tests.sh
+++ b/docker-tests/run-docker-tests.sh
@@ -36,6 +36,7 @@ info() {
 }
 
 tmp_dir=$(mktemp -d -t innernet-tests-XXXXXXXXXX)
+info "temp dir: $tmp_dir"
 cleanup() {
     info "Cleaning up."
     rm -rf "$tmp_dir"


### PR DESCRIPTION
At some point, the golang and rustlang docker images decided that `latest` meant different things. Golang was building on the new `bookworm` Debian version, while Rust wasn't. This forces them both to a specific version of Debian to avoid glibc conflicts.