### PR TITLE
 Add Error Message when wireguard-go not found. replacement for #232

### DIFF
--- a/wireguard-control/src/backends/userspace.rs
+++ b/wireguard-control/src/backends/userspace.rs
@@ -274,6 +274,34 @@ fn get_userspace_implementation() -> String {
 
 fn start_userspace_wireguard(iface: &InterfaceName) -> io::Result<Output> {
     let mut command = Command::new(get_userspace_implementation());
+
+    let output_res = if cfg!(target_os = "linux") {
+        command.args(&[iface.to_string()]).output()
+    } else {
+        command
+            .env("WG_TUN_NAME_FILE", &format!("{VAR_RUN_PATH}/{iface}.name"))
+            .args(["utun"])
+            .output()
+    };
+
+    match output_res {
+        Ok(output) => {
+            if output.status.success() {
+                Ok(output)
+            } else {
+                Err(io::ErrorKind::AddrNotAvailable.into())
+            }
+        },
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "Cannot find \"wireguard-go\". Specify a custom path with WG_USERSPACE_IMPLEMENTATION.",
+        )),
+        Err(e) => Err(e),
+    }
+}
+
+fn _start_userspace_wireguard(iface: &InterfaceName) -> io::Result<Output> {
+    let mut command = Command::new(get_userspace_implementation());
     let output = if cfg!(target_os = "linux") {
         command.args(&[iface.to_string()]).output()?
     } else {

--- a/wireguard-control/src/backends/userspace.rs
+++ b/wireguard-control/src/backends/userspace.rs
@@ -300,23 +300,6 @@ fn start_userspace_wireguard(iface: &InterfaceName) -> io::Result<Output> {
     }
 }
 
-fn _start_userspace_wireguard(iface: &InterfaceName) -> io::Result<Output> {
-    let mut command = Command::new(get_userspace_implementation());
-    let output = if cfg!(target_os = "linux") {
-        command.args(&[iface.to_string()]).output()?
-    } else {
-        command
-            .env("WG_TUN_NAME_FILE", &format!("{VAR_RUN_PATH}/{iface}.name"))
-            .args(["utun"])
-            .output()?
-    };
-    if !output.status.success() {
-        Err(io::ErrorKind::AddrNotAvailable.into())
-    } else {
-        Ok(output)
-    }
-}
-
 pub fn apply(builder: &DeviceUpdate, iface: &InterfaceName) -> io::Result<()> {
     // If we can't open a configuration socket to an existing interface, try starting it.
     let mut sock = match open_socket(iface) {


### PR DESCRIPTION
Previously when trying to add a peer, i for the following output, which
was not helpful since i wasn't sure what file could not be found.
```
bkn@mbp16 bkn % sudo /Users/bkn/.cargo/bin/innernet  --verbose  install mbp16.toml
✔ Interface name · chester
[*] bringing up interface chester.
[E] failed to start the interface: chester - No such file or directory (os error 2).
[*] bringing down the interface.
[!] failed to bring down interface: chester - WireGuard name file can't be read.
[E] Failed to redeem invite. Now's a good time to make sure the server is started and accessible!

[E] chester - No such file or directory (os error 2)
```

After changes: 
```
[1] bkn@mbp16> sudo target/debug/innernet --verbose  install /Users/brad/mbp16.conf             /Users/brad/source/rust/innernet
✔ Interface name · chester2
[*] bringing up interface chester2.
[E] failed to start the interface: chester2 - Cannot find "wireguard-go". Specify a custom path with WG_USERSPACE_IMPLEMENTATION..
[*] bringing down the interface.
[!] failed to bring down interface: chester2 - WireGuard name file can't be read.
[E] Failed to redeem invite. Now's a good time to make sure the server is started and accessible!

[E] chester2 - Cannot find "wireguard-go". Specify a custom path with WG_USERSPACE_IMPLEMENTATION.
```

ref  new PR to replace #232