### PR TITLE
Report wireguard endpoint as a candidate when an endpoint override is in place

### DIFF
--- a/hostsfile/src/lib.rs
+++ b/hostsfile/src/lib.rs
@@ -198,6 +198,7 @@ impl HostsBuilder {
 
         let hosts_file = OpenOptions::new()
             .create(true)
+            .truncate(false)
             .read(true)
             .write(true)
             .open(hosts_path)?;

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -13,17 +13,15 @@ pub mod user;
 pub fn inject_endpoints(session: &Session, peers: &mut Vec<Peer>) {
     for peer in peers {
         let endpoints = session.context.endpoints.read();
-        let wg_endpoint = endpoints.get(&peer.public_key);
-
-        if peer.contents.endpoint.is_some() {
-            if let Some(wg_endpoint) = wg_endpoint {
+        if let Some(wg_endpoint) = endpoints.get(&peer.public_key) {
+            if peer.contents.endpoint.is_none() {
+                peer.contents.endpoint = Some(wg_endpoint.to_owned().into());
+            } else {
                 // The peer already has an endpoint specified, but it might be stale.
                 // If there is an endpoint reported from wireguard, we should add it
                 // to the list of candidates so others can try to connect using it.
                 peer.contents.candidates.push(wg_endpoint.to_owned().into());
             }
-        } else if let Some(wg_endpoint) = wg_endpoint {
-            peer.contents.endpoint = Some(wg_endpoint.to_owned().into());
         }
     }
 }

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -6,13 +6,24 @@ pub mod admin;
 pub mod user;
 
 /// Inject the collected endpoints from the WG interface into a list of peers.
-/// This is essentially what adds NAT holepunching functionality.
+/// This is essentially what adds NAT holepunching functionality. If a peer
+/// already has an endpoint specified (by calling the override-endpoint) API,
+/// the relatively recent wireguard endpoint will be added to the list of NAT
+/// candidates, so other peers have a better chance of connecting.
 pub fn inject_endpoints(session: &Session, peers: &mut Vec<Peer>) {
     for peer in peers {
-        if peer.contents.endpoint.is_none() {
-            if let Some(endpoint) = session.context.endpoints.read().get(&peer.public_key) {
-                peer.contents.endpoint = Some(endpoint.to_owned().into());
+        let endpoints = session.context.endpoints.read();
+        let wg_endpoint = endpoints.get(&peer.public_key);
+
+        if peer.contents.endpoint.is_some() {
+            if let Some(wg_endpoint) = wg_endpoint {
+                // The peer already has an endpoint specified, but it might be stale.
+                // If there is an endpoint reported from wireguard, we should add it
+                // to the list of candidates so others can try to connect using it.
+                peer.contents.candidates.push(wg_endpoint.to_owned().into());
             }
+        } else if let Some(wg_endpoint) = wg_endpoint {
+            peer.contents.endpoint = Some(wg_endpoint.to_owned().into());
         }
     }
 }

--- a/server/src/api/user.rs
+++ b/server/src/api/user.rs
@@ -169,10 +169,7 @@ mod handlers {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        str::FromStr,
-        time::{Duration, SystemTime},
-    };
+    use std::time::{Duration, SystemTime};
 
     use super::*;
     use crate::{db::DatabaseAssociation, test};
@@ -509,7 +506,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             developer_1.endpoint,
-            Some(Endpoint::from_str(test::DEVELOPER1_PEER_ENDPOINT).unwrap())
+            Some(test::DEVELOPER1_PEER_ENDPOINT.parse().unwrap())
         );
         assert_eq!(developer_1.candidates, candidates);
 
@@ -544,15 +541,12 @@ mod tests {
             .unwrap();
 
         // The peer endpoint should be the one we just specified in the override-endpoint request.
-        assert_eq!(
-            developer_1.endpoint,
-            Some(Endpoint::from_str("1.2.3.4:51820").unwrap())
-        );
+        assert_eq!(developer_1.endpoint, Some("1.2.3.4:51820".parse().unwrap()));
 
         // The list of candidates should now contain the one we specified at the beginning of the
         // test, and the wireguard-reported endpoint of the peer.
-        let nat_candidate_1 = Endpoint::from_str("1.1.1.1:51820").unwrap();
-        let nat_candidate_2 = Endpoint::from_str(test::DEVELOPER1_PEER_ENDPOINT).unwrap();
+        let nat_candidate_1 = "1.1.1.1:51820".parse().unwrap();
+        let nat_candidate_2 = test::DEVELOPER1_PEER_ENDPOINT.parse().unwrap();
         assert_eq!(developer_1.candidates.len(), 2);
         assert!(developer_1.candidates.contains(&nat_candidate_1));
         assert!(developer_1.candidates.contains(&nat_candidate_2));

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -147,7 +147,7 @@ pub type Endpoints = Arc<RwLock<HashMap<String, SocketAddr>>>;
 #[derive(Clone)]
 pub struct Context {
     pub db: Db,
-    pub endpoints: Arc<RwLock<HashMap<String, SocketAddr>>>,
+    pub endpoints: Endpoints,
     pub interface: InterfaceName,
     pub backend: Backend,
     pub public_key: Key,


### PR DESCRIPTION
Scenario: you have a machine which at one point ran `innernet override-endpoint` with an endpoint which _maybe_ worked in the past, but doesn't work now. Because the endpoint is overridden, it is _the_ endpoint peers try, along with any extra endpoint candidates reported by the peer.

What _doesn't_ get reported to other peers is the current wireguard endpoint the innernet server sees. It used to only use that wg endpoint if the peer hadn't overridden it.

The easiest fix I can think of is to just add the endpoint the server sees to the list of NAT candidates we give peers to try.

The server logic could perhaps be simplified further - report all possible candidates we know about on the server side, and maybe allow the client to specify additional endpoints it wants to use as candidates. But for now this PR is probably sufficient?

I haven't tested yet, and it might need more tests added to our CI to cover this case.