### PR TITLE
Fix 1.81 lints (extra reference and never type fallback)

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -473,7 +473,7 @@ fn redeem_invite(
         "Registering keypair with server (at {}).",
         &config.server.internal_endpoint
     );
-    Api::new(&config.server).http_form(
+    Api::new(&config.server).http_form::<_, ()>(
         "POST",
         "/user/redeem",
         RedeemContents {
@@ -742,7 +742,7 @@ fn rename_cidr(
             .ok_or_else(|| anyhow!("CIDR not found."))?
             .id;
 
-        api.http_form("PUT", &format!("/admin/cidrs/{id}"), cidr_request)?;
+        api.http_form::<_, ()>("PUT", &format!("/admin/cidrs/{id}"), cidr_request)?;
         log::info!("CIDR renamed.");
     } else {
         log::info!("Exited without renaming CIDR.");
@@ -766,7 +766,7 @@ fn delete_cidr(
     let cidr_id = prompts::delete_cidr(&cidrs, &peers, &sub_opts)?;
 
     println!("Deleting CIDR...");
-    api.http("DELETE", &format!("/admin/cidrs/{cidr_id}"))?;
+    api.http::<()>("DELETE", &format!("/admin/cidrs/{cidr_id}"))?;
 
     println!("CIDR deleted.");
 
@@ -842,7 +842,7 @@ fn rename_peer(
             .next()
             .ok_or_else(|| anyhow!("Peer not found."))?;
 
-        api.http_form("PUT", &format!("/admin/peers/{id}"), peer_request)?;
+        api.http_form::<_, ()>("PUT", &format!("/admin/peers/{id}"), peer_request)?;
         log::info!("Peer renamed.");
     } else {
         log::info!("exited without renaming peer.");
@@ -867,7 +867,7 @@ fn enable_or_disable_peer(
     if let Some(peer) = prompts::enable_or_disable_peer(&peers[..], &sub_opts, enable)? {
         let Peer { id, mut contents } = peer;
         contents.is_disabled = !enable;
-        api.http_form("PUT", &format!("/admin/peers/{id}"), contents)?;
+        api.http_form::<_, ()>("PUT", &format!("/admin/peers/{id}"), contents)?;
     } else {
         log::info!("exiting without enabling or disabling peer.");
     }
@@ -905,7 +905,7 @@ fn add_association(
         return Ok(());
     };
 
-    api.http_form(
+    api.http_form::<_, ()>(
         "POST",
         "/admin/associations",
         AssociationContents {
@@ -934,7 +934,7 @@ fn delete_association(
     if let Some(association) =
         prompts::delete_association(&associations[..], &cidrs[..], &sub_opts)?
     {
-        api.http("DELETE", &format!("/admin/associations/{}", association.id))?;
+        api.http::<()>("DELETE", &format!("/admin/associations/{}", association.id))?;
     } else {
         log::info!("exiting without adding association.");
     }
@@ -1016,7 +1016,7 @@ fn override_endpoint(
 
     if let Some(contents) = endpoint_contents {
         log::info!("requesting endpoint update...");
-        Api::new(&config.server).http_form("PUT", "/user/endpoint", contents)?;
+        Api::new(&config.server).http_form::<_, ()>("PUT", "/user/endpoint", contents)?;
         log::info!(
             "endpoint override {}",
             if sub_opts.unset { "unset" } else { "set" }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -290,7 +290,7 @@ fn update_hosts_file(
     for peer in peers {
         hosts_builder.add_hostname(
             peer.contents.ip,
-            &format!("{}.{}.wg", peer.contents.name, interface),
+            format!("{}.{}.wg", peer.contents.name, interface),
         );
     }
     match hosts_builder.write_to(&hosts_path).with_path(&hosts_path) {
@@ -374,7 +374,7 @@ fn install(
     if install_opts.delete_invite
         || Confirm::with_theme(&*prompts::THEME)
             .wait_for_newline(true)
-            .with_prompt(&format!(
+            .with_prompt(format!(
                 "Delete invitation file \"{}\" now? (It's no longer needed)",
                 invite.to_string_lossy().yellow()
             ))
@@ -666,7 +666,7 @@ fn uninstall(interface: &InterfaceName, opts: &Opts, yes: bool) -> Result<(), Er
 
     if yes
         || Confirm::with_theme(&*prompts::THEME)
-            .with_prompt(&format!(
+            .with_prompt(format!(
                 "Permanently delete network \"{}\"?",
                 interface.as_str_lossy().yellow()
             ))

--- a/docker-tests/Dockerfile.innernet
+++ b/docker-tests/Dockerfile.innernet
@@ -1,7 +1,10 @@
 ####################################################################################################
 ## WireGuard
 ####################################################################################################
-FROM golang:bookworm as wireguard
+
+# Pin go 1.22 as the latest tag of wireguard-go (0.0.20230223) doesn't build with go 1.23+ due to
+# its outdated x/net dependency. We can use latest go once they release newer version.
+FROM golang:1.22-bookworm as wireguard
 ARG wg_go_tag=0.0.20230223
 
 RUN mkdir /repo \

--- a/docker-tests/Dockerfile.innernet
+++ b/docker-tests/Dockerfile.innernet
@@ -5,7 +5,7 @@ FROM golang:bookworm as wireguard
 ARG wg_go_tag=0.0.20230223
 
 RUN mkdir /repo \
-    && curl -L https://github.com/WireGuard/wireguard-go/archive/refs/tags/0.0.20230223.tar.gz \
+    && curl -L https://github.com/WireGuard/wireguard-go/archive/refs/tags/${wg_go_tag}.tar.gz \
     | tar -xzC /repo --strip-components=1 \
     && cd /repo \
     && CGO_ENABLED=0 make

--- a/docker-tests/Dockerfile.innernet
+++ b/docker-tests/Dockerfile.innernet
@@ -3,7 +3,6 @@
 ####################################################################################################
 FROM golang:bookworm as wireguard
 ARG wg_go_tag=0.0.20230223
-ARG wg_tools_tag=v1.0.20210914
 
 RUN mkdir /repo \
     && curl -L https://github.com/WireGuard/wireguard-go/archive/refs/tags/0.0.20230223.tar.gz \

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -522,7 +522,7 @@ fn uninstall(
 ) -> Result<(), Error> {
     if yes
         || Confirm::with_theme(&*prompts::THEME)
-            .with_prompt(&format!(
+            .with_prompt(format!(
                 "Permanently delete network \"{}\"?",
                 interface.as_str_lossy().yellow()
             ))

--- a/wireguard-control/src/backends/userspace.rs
+++ b/wireguard-control/src/backends/userspace.rs
@@ -278,7 +278,7 @@ fn start_userspace_wireguard(iface: &InterfaceName) -> io::Result<Output> {
         command.args(&[iface.to_string()]).output()?
     } else {
         command
-            .env("WG_TUN_NAME_FILE", &format!("{VAR_RUN_PATH}/{iface}.name"))
+            .env("WG_TUN_NAME_FILE", format!("{VAR_RUN_PATH}/{iface}.name"))
             .args(["utun"])
             .output()?
     };


### PR DESCRIPTION
### Fix "no need for reference" clippy 1.81 lints

### Fix `dependency_on_unit_never_type_fallback` lint

This relates to
- rust-lang/rust#123748
- https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html

And frankly I still don't really understand why never type was involved in our code in the first place.

