### PR TITLE
Fix build of testing Docker images by pinning golang to 1.22

### DIFF
--- a/docker-tests/Dockerfile.innernet
+++ b/docker-tests/Dockerfile.innernet
@@ -1,7 +1,10 @@
 ####################################################################################################
 ## WireGuard
 ####################################################################################################
-FROM golang:bookworm as wireguard
+
+# Pin go 1.22 as the latest tag of wireguard-go (0.0.20230223) doesn't build with go 1.23+ due to
+# its outdated x/net dependency. We can use latest go once they release newer version.
+FROM golang:1.22-bookworm as wireguard
 ARG wg_go_tag=0.0.20230223
 
 RUN mkdir /repo \

--- a/docker-tests/Dockerfile.innernet
+++ b/docker-tests/Dockerfile.innernet
@@ -5,7 +5,7 @@ FROM golang:bookworm as wireguard
 ARG wg_go_tag=0.0.20230223
 
 RUN mkdir /repo \
-    && curl -L https://github.com/WireGuard/wireguard-go/archive/refs/tags/0.0.20230223.tar.gz \
+    && curl -L https://github.com/WireGuard/wireguard-go/archive/refs/tags/${wg_go_tag}.tar.gz \
     | tar -xzC /repo --strip-components=1 \
     && cd /repo \
     && CGO_ENABLED=0 make

--- a/docker-tests/Dockerfile.innernet
+++ b/docker-tests/Dockerfile.innernet
@@ -3,7 +3,6 @@
 ####################################################################################################
 FROM golang:bookworm as wireguard
 ARG wg_go_tag=0.0.20230223
-ARG wg_tools_tag=v1.0.20210914
 
 RUN mkdir /repo \
     && curl -L https://github.com/WireGuard/wireguard-go/archive/refs/tags/0.0.20230223.tar.gz \


### PR DESCRIPTION
- on top of https://github.com/tonarino/innernet/pull/322

### Dockerfile.innernet: remove unused wg_tools_tag ARG

### Dockerfile.innernet: actually use the wg_go_tag ARG

## Fix build of testing Docker images by pinning golang to 1.22

Thanks to great pointer by @sqrtsanta in https://github.com/tonarino/innernet/pull/320#issuecomment-2337438311