### PR TITLE
Refresh CI: pass --worspace, --locked, reformat

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -2,20 +2,17 @@ name: Docker tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Build the Docker images
-      run: docker-tests/build-docker-images.sh
-    - name: Run the Docker tests
-      run: docker-tests/run-docker-tests.sh --userspace --verbose
-
+      - uses: actions/checkout@v4
+      - name: Build the Docker images
+        run: docker-tests/build-docker-images.sh
+      - name: Run the Docker tests
+        run: docker-tests/run-docker-tests.sh --userspace --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,12 +3,12 @@ name: Rust
 on:
   push:
     branches:
-    - '*'
+      - "*"
     tags-ignore:
-    - 'v*'
+      - "v*"
   pull_request:
     branches:
-    - '*'
+      - "*"
 
 jobs:
   test:
@@ -19,62 +19,62 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-    - name: Install Dependencies (if Ubuntu)
-      env:
-        ACCEPT_EULA: Y
-      run: sudo apt-get -y update && sudo apt-get install -f && sudo apt-get -y install libsqlite3-dev libclang-19-dev
-      if: contains(runner.os, 'Linux')
-    - uses: Swatinem/rust-cache@v1
-    - name: Build
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --verbose
-    - name: Test
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --verbose
-    - name: Test (IPv6)
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --features v6-test --verbose
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Install Dependencies (if Ubuntu)
+        env:
+          ACCEPT_EULA: Y
+        run: sudo apt-get -y update && sudo apt-get install -f && sudo apt-get -y install libsqlite3-dev libclang-19-dev
+        if: contains(runner.os, 'Linux')
+      - uses: Swatinem/rust-cache@v1
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --workspace --locked --verbose
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --locked --verbose
+      - name: Test (IPv6)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --locked --features v6-test --verbose
 
   fmt:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: nightly
-        override: true
-        components: rustfmt
-    - name: Rustfmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: rustfmt
+      - name: Rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
 
   clippy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        components: clippy
-    - name: Clippy
-      uses: actions-rs/cargo@v1
-      with:
-        command: clippy
-        args: --all-targets -- -D warnings
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: clippy
+      - name: Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --workspace --locked --all-targets -- -D warnings


### PR DESCRIPTION
The first commit fails the CI - because `Cargo.lock` was not udpated (in some prior PRs), which demonstrates why `--locked` is useful.

~The second commit updates `Cargo.lock` (just the necessary changes, not the full update).~