### PR TITLE
Upgrade dialoguer to 0.11 to fix prefilled prompts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,15 +319,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
 dependencies = [
  "encode_unicode",
+ "lazy_static",
  "libc",
- "once_cell",
  "unicode-width",
- "windows-sys 0.59.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -367,12 +367,13 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
 dependencies = [
  "console",
  "shell-words",
+ "thiserror",
 ]
 
 [[package]]
@@ -400,9 +401,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
-version = "1.0.0"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "env_logger"
@@ -1732,9 +1733,9 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.1"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "ureq"
@@ -1858,6 +1859,15 @@ checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -1881,6 +1891,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -1918,6 +1943,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -1930,6 +1961,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -1939,6 +1976,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1966,6 +2009,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -1975,6 +2024,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1990,6 +2045,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -1999,6 +2060,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ codegen-units = 1
 lto = "fat"
 opt-level = "s"
 panic = "abort"
+
+[workspace.dependencies]
+dialoguer = { version = "0.11", default-features = false }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -24,7 +24,7 @@ anyhow = "1"
 colored = "2"
 clap = { version = "4.3", features = ["derive", "wrap_help"] }
 clap_complete = "4.3"
-dialoguer = { version = "0.10", default-features = false }
+dialoguer.workspace = true
 indoc = "2.0.1"
 ipnet = { version = "2.4", features = ["serde"] }
 log = "0.4"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -31,7 +31,7 @@ bytes = "1"
 clap = { version = "4.3", features = ["derive", "wrap_help"] }
 clap_complete = "4.3"
 colored = "2"
-dialoguer = { version = "0.10", default-features = false }
+dialoguer.workspace = true
 hyper = { version = "0.14", default-features = false, features = [
   "http1",
   "server",

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1"
 atty = "0.2"
 clap = { version = "4.3", features = ["derive", "wrap_help"] }
 colored = "2.0"
-dialoguer = { version = "0.10", default-features = false }
+dialoguer.workspace = true
 hostsfile = { path = "../hostsfile" }
 indoc = "2.0.1"
 ipnet = { version = "2.4", features = ["serde"] }

--- a/shared/src/prompts.rs
+++ b/shared/src/prompts.rs
@@ -33,7 +33,7 @@ pub fn ensure_interactive(prompt: &str) -> Result<(), io::Error> {
     }
 }
 
-pub fn confirm(prompt: &str) -> Result<bool, io::Error> {
+pub fn confirm(prompt: &str) -> Result<bool, dialoguer::Error> {
     ensure_interactive(prompt)?;
     Confirm::with_theme(&*THEME)
         .wait_for_newline(true)
@@ -42,7 +42,10 @@ pub fn confirm(prompt: &str) -> Result<bool, io::Error> {
         .interact()
 }
 
-pub fn select<'a, T: ToString>(prompt: &str, items: &'a [T]) -> Result<(usize, &'a T), io::Error> {
+pub fn select<'a, T: ToString>(
+    prompt: &str,
+    items: &'a [T],
+) -> Result<(usize, &'a T), dialoguer::Error> {
     ensure_interactive(prompt)?;
     let choice = Select::with_theme(&*THEME)
         .with_prompt(prompt)
@@ -57,17 +60,17 @@ pub enum Prefill<T> {
     None,
 }
 
-pub fn input<T>(prompt: &str, prefill: Prefill<T>) -> Result<T, io::Error>
+pub fn input<T>(prompt: &str, prefill: Prefill<T>) -> Result<T, dialoguer::Error>
 where
     T: Clone + FromStr + Display,
     T::Err: Display + Debug,
 {
     ensure_interactive(prompt)?;
-    let mut input = Input::with_theme(&*THEME);
+    let input = Input::with_theme(&*THEME);
     match prefill {
         Prefill::Default(value) => input.default(value),
         Prefill::Editable(value) => input.with_initial_text(value),
-        _ => &mut input,
+        _ => input,
     }
     .with_prompt(prompt)
     .interact()
@@ -535,8 +538,7 @@ pub fn set_listen_port(
         None
     };
 
-    let mut confirmation = Confirm::with_theme(&*THEME);
-    confirmation
+    let confirmation = Confirm::with_theme(&*THEME)
         .wait_for_newline(true)
         .with_prompt(
             &(if let Some(port) = &listen_port {


### PR DESCRIPTION
Fixes #338 

https://github.com/console-rs/dialoguer/blob/master/CHANGELOG.md#0110

## 0.11.0

### Enhancements

* Added `dialoguer::Result` and `dialoguer::Error`
* Added a `BasicHistory` implementation for `History`
* Added vim mode for `FuzzySelect`
* All prompts implement `Clone`
* Add handling of `Delete` key for `FuzzySelect`

### Bug fixes

* Resolve some issues on Windows where pressing shift keys sometimes aborted dialogs
* Resolve `MultiSelect` checked and unchecked variants looking the same on Windows
* `Input` values that are invalid are now also stored in `History`
* Resolve some issues with cursor positioning in `Input` when using `utf-8` characters
* Correct page is shown when default selected option is not on the first page for `Select`
* Fix panic in `FuzzySelect` when using non-ASCII characters

### Breaking

* Updated MSRV to `1.63.0` due to multiple dependencies on different platforms: `rustix`, `tempfile`,`linux-raw-sys`
* Removed deprecated `Confirm::with_text`
* Removed deprecated `ColorfulTheme::inline_selections`
* Prompt builder functions now take `mut self` instead of `&mut self`
* Prompt builder functions now return `Self` instead of `&mut Self`
* Prompt interaction functions now take `self` instead of `&self`
* Prompt interaction functions and other operations now return `dialoguer::Result` instead of `std::io::Result`
* Rename `Validator` to `InputValidator`
* The trait method `Theme::format_fuzzy_select_prompt()` now takes a byte position instead of a cursor position in order to support UTF-8.
