### PR TITLE
Fix bug that prevented preserving SELinux context and add tests

### DIFF
--- a/hostsfile/src/lib.rs
+++ b/hostsfile/src/lib.rs
@@ -447,9 +447,12 @@ mod tests {
         let initial_context =
             SecurityContext::of_path(&hosts_path, FOLLOW_SYMLINKS, RAW_FORMAT).unwrap();
 
-        let initial_context_str = initial_context
-            .as_ref()
-            .map(|c| c.to_c_string().ok().flatten().map(|s| s.to_string_lossy().into_owned()));
+        let initial_context_str = initial_context.as_ref().map(|c| {
+            c.to_c_string()
+                .ok()
+                .flatten()
+                .map(|s| s.to_string_lossy().into_owned())
+        });
         println!("Initial SELinux context: {:?}", initial_context_str);
 
         // Use write_to which internally uses write_and_swap
@@ -461,9 +464,12 @@ mod tests {
         let final_context =
             SecurityContext::of_path(&hosts_path, FOLLOW_SYMLINKS, RAW_FORMAT).unwrap();
 
-        let final_context_str = final_context
-            .as_ref()
-            .map(|c| c.to_c_string().ok().flatten().map(|s| s.to_string_lossy().into_owned()));
+        let final_context_str = final_context.as_ref().map(|c| {
+            c.to_c_string()
+                .ok()
+                .flatten()
+                .map(|s| s.to_string_lossy().into_owned())
+        });
         println!("Final SELinux context: {:?}", final_context_str);
 
         assert_eq!(

--- a/rpm/Dockerfile
+++ b/rpm/Dockerfile
@@ -6,7 +6,7 @@ FROM ${DISTRO}:${VER} as builder
 LABEL stage=innernet-rpm
 
 RUN yum -y update && \
-	yum -y install gcc clang-devel sqlite-devel glibc-devel rpm-build && \
+	yum -y install gcc clang-devel sqlite-devel glibc-devel rpm-build libselinux-devel && \
 	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
 
 WORKDIR /workdir
@@ -15,7 +15,7 @@ RUN rm -rf target
 
 RUN source $HOME/.cargo/env && \
 	cargo install cargo-rpm && \
-	cargo build --release --verbose && \
+	cargo build --release --verbose --features innernet/selinux && \
 	# device::tests::test_add_peers will fail due to restricted docker env
 	cargo test --release --verbose -- --skip test_add_peers && \
 	cd server && cargo rpm build && \


### PR DESCRIPTION
 Fixed a small bug in `get_temp_path()` where temp files were created in the wrong directory. This caused `hosts_dir.with_file_name(temp_filename)` to produce `/hosts.tmpXXX` instead of `/etc/hosts.tmpXXX`, which in turn broke SELinux context preservation.

Also added tests to verify temp file location and SELinux context preservation.
