### PR TITLE
Introduce a core Context type

### DIFF
--- a/client-core/examples/add_cidr.rs
+++ b/client-core/examples/add_cidr.rs
@@ -1,0 +1,30 @@
+use anyhow::{Context, Error};
+use env_logger::Env;
+use innernet_client_core::{
+    interface::{InterfaceConfig, InterfaceName},
+    rest_client::RestClient,
+    CidrContents, DEFAULT_CONFIG_DIR,
+};
+use std::{env, path::Path};
+
+fn main() -> Result<(), Error> {
+    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
+
+    let config_dir = Path::new(DEFAULT_CONFIG_DIR);
+    let interface = env::args().nth(1).context("Usage: add_cidr <interface>")?;
+
+    let interface: InterfaceName = interface.parse()?;
+    let interface_config = InterfaceConfig::from_interface(config_dir, &interface)?;
+    let rest_client = RestClient::new(&interface_config.server);
+    let cidrs = rest_client.get_cidrs()?;
+
+    let name = "example".to_owned();
+    let cidr = "10.49.65.0/24".parse()?;
+    let parent = &cidrs[0];
+
+    let cidr_contents = CidrContents::new(name, cidr, parent);
+    let cidr = rest_client.create_cidr(&cidr_contents)?;
+    dbg!(&cidr);
+
+    Ok(())
+}

--- a/client-core/examples/add_cidr.rs
+++ b/client-core/examples/add_cidr.rs
@@ -1,10 +1,6 @@
-use anyhow::{Context, Error};
+use anyhow::{Context as _, Error};
 use env_logger::Env;
-use innernet_client_core::{
-    interface::{InterfaceConfig, InterfaceName},
-    rest_client::RestClient,
-    CidrContents, DEFAULT_CONFIG_DIR,
-};
+use innernet_client_core::{interface::InterfaceName, CidrContents, Context, DEFAULT_CONFIG_DIR};
 use std::{env, path::Path};
 
 fn main() -> Result<(), Error> {
@@ -12,18 +8,16 @@ fn main() -> Result<(), Error> {
 
     let config_dir = Path::new(DEFAULT_CONFIG_DIR);
     let interface = env::args().nth(1).context("Usage: add_cidr <interface>")?;
-
     let interface: InterfaceName = interface.parse()?;
-    let interface_config = InterfaceConfig::from_interface(config_dir, &interface)?;
-    let rest_client = RestClient::new(&interface_config.server);
-    let cidrs = rest_client.get_cidrs()?;
+    let context = Context::new(config_dir.into(), interface)?;
 
     let name = "example".to_owned();
     let cidr = "10.49.65.0/24".parse()?;
+    let cidrs = context.rest_client().get_cidrs()?;
     let parent = &cidrs[0];
 
     let cidr_contents = CidrContents::new(name, cidr, parent);
-    let cidr = rest_client.create_cidr(&cidr_contents)?;
+    let cidr = context.rest_client().create_cidr(&cidr_contents)?;
     dbg!(&cidr);
 
     Ok(())

--- a/client-core/examples/add_peer.rs
+++ b/client-core/examples/add_peer.rs
@@ -1,10 +1,9 @@
-use anyhow::{Context, Error};
+use anyhow::{Context as _, Error};
 use env_logger::Env;
 use innernet_client_core::{
-    interface::{InterfaceConfig, InterfaceName},
+    interface::InterfaceName,
     peer::{create_peer, NewPeerInfo},
-    rest_client::RestClient,
-    DEFAULT_CONFIG_DIR,
+    Context, DEFAULT_CONFIG_DIR,
 };
 use innernet_shared::prompts;
 use std::{
@@ -20,10 +19,8 @@ fn main() -> Result<(), Error> {
     let interface = env::args().nth(1).context("Usage: add_peer <interface>")?;
 
     let interface: InterfaceName = interface.parse()?;
-    let interface_config = InterfaceConfig::from_interface(config_dir, &interface)?;
-    let rest_client = RestClient::new(&interface_config.server);
-    let cidrs = rest_client.get_cidrs()?;
-    let peers = rest_client.get_peers()?;
+    let context = Context::new(config_dir.into(), interface)?;
+    let cidrs = context.rest_client().get_cidrs()?;
 
     let new_peer_info = NewPeerInfo {
         name: "joe".parse().unwrap(),
@@ -34,7 +31,7 @@ fn main() -> Result<(), Error> {
     };
 
     let target_path = "invitation.toml";
-    let (peer, invitation) = create_peer(config_dir, &interface, &cidrs, &peers, new_peer_info)?;
+    let (peer, invitation) = create_peer(&context, &cidrs, new_peer_info)?;
     invitation.save_new(target_path)?;
     prompts::print_invitation_info(&peer, target_path);
 

--- a/client-core/examples/set_listen_port.rs
+++ b/client-core/examples/set_listen_port.rs
@@ -1,8 +1,7 @@
 use anyhow::{Context as _, Error};
 use env_logger::Env;
 use innernet_client_core::{
-    interface::{InterfaceConfig, InterfaceName},
-    set_listen_port, DEFAULT_CONFIG_DIR,
+    interface::InterfaceName, set_listen_port, Context, DEFAULT_CONFIG_DIR,
 };
 use log::info;
 use std::{env, path::Path};
@@ -12,24 +11,19 @@ fn main() -> Result<(), Error> {
 
     let interface = env::args()
         .nth(1)
-        .context("Usage: add_peer <interface> [listen_port]")?;
+        .context("Usage: set_listen_port <interface> [listen_port]")?;
     let interface: InterfaceName = interface.parse()?;
-
-    let listen_port: Option<u16> = env::args().nth(2).map(|port| port.parse()).transpose()?;
-
     let config_dir = Path::new(DEFAULT_CONFIG_DIR);
-    let mut config = InterfaceConfig::from_interface(config_dir, &interface)?;
+    let mut context = Context::new(config_dir.into(), interface)?;
+
+    info!(
+        "Current listen port: {:?}",
+        context.interface_info().listen_port
+    );
+
     let network_backend = Default::default();
-
-    info!("Current listen port: {:?}", config.interface.listen_port);
-
-    set_listen_port(
-        network_backend,
-        config_dir,
-        &interface,
-        &mut config,
-        listen_port,
-    )?;
+    let listen_port: Option<u16> = env::args().nth(2).map(|port| port.parse()).transpose()?;
+    set_listen_port(&mut context, network_backend, listen_port)?;
 
     Ok(())
 }

--- a/client-core/src/interface.rs
+++ b/client-core/src/interface.rs
@@ -5,7 +5,7 @@ use crate::{
     data_store::DataStore,
     nat::{self, NatTraverse},
     rest_client::{RestClient, RestError},
-    HostsOpts, NatOpts, NetworkOpts, WrappedIoError,
+    Context, HostsOpts, NatOpts, NetworkOpts, WrappedIoError,
 };
 use anyhow::{bail, Context as _, Error};
 use colored::{ColoredString, Colorize};
@@ -123,7 +123,8 @@ fn update_keypair(
         "Registering keypair with server (at {}).",
         &config.server.internal_endpoint
     );
-    RestClient::new(&config.server).http_form::<_, ()>(
+    let agent = RestClient::create_agent();
+    RestClient::new(&agent, &config.server).http_form::<_, ()>(
         "POST",
         "/user/redeem",
         RedeemContents {
@@ -154,15 +155,16 @@ fn update_keypair(
 }
 
 pub fn fetch(
-    config_dir: &Path,
+    context: &Context,
     data_dir: &Path,
     network_opts: &NetworkOpts,
     hosts_opts: &HostsOpts,
     nat: &NatOpts,
-    interface: &InterfaceName,
     bring_up_interface: bool,
 ) -> Result<(), Error> {
-    let config = InterfaceConfig::from_interface(config_dir, interface)?;
+    let interface = &context.interface;
+    let interface_info = context.interface_info();
+    let server_info = context.server_info();
     let interface_up = match Device::list(network_opts.backend) {
         Ok(interfaces) => interfaces.iter().any(|name| name == interface),
         _ => false,
@@ -180,19 +182,19 @@ pub fn fetch(
             "bringing up interface {}.",
             interface.as_str_lossy().yellow()
         );
-        let resolved_endpoint = config
-            .server
+        let resolved_endpoint = context
+            .server_info()
             .external_endpoint
             .resolve()
-            .context(config.server.external_endpoint.to_string())?;
+            .context(server_info.external_endpoint.to_string())?;
         wg::up(
             interface,
-            &config.interface.private_key,
-            config.interface.address,
-            config.interface.listen_port,
+            &interface_info.private_key,
+            interface_info.address,
+            interface_info.listen_port,
             Some((
-                &config.server.public_key,
-                config.server.internal_endpoint.ip(),
+                &server_info.public_key,
+                server_info.internal_endpoint.ip(),
                 resolved_endpoint,
             )),
             network_opts,
@@ -205,9 +207,7 @@ pub fn fetch(
         interface.as_str_lossy().yellow()
     );
     let mut store = DataStore::open_or_create(data_dir, interface)?;
-    let rest_client = RestClient::new(&config.server);
-    let (State { peers, cidrs }, server_is_reachable) = match rest_client.http("GET", "/user/state")
-    {
+    let (State { peers, cidrs }, server_is_reachable) = match context.rest_client().get_state() {
         Ok(state) => (state, true),
         Err(e) => {
             if e.is_transport_error() {
@@ -266,7 +266,7 @@ pub fn fetch(
 
     let listen_port = device.listen_port.unwrap_or(51820);
     if server_is_reachable {
-        report_candidates(&rest_client, nat, listen_port)?;
+        report_candidates(&context.rest_client(), nat, listen_port)?;
     }
 
     if nat.no_nat_traversal {

--- a/client-core/src/lib.rs
+++ b/client-core/src/lib.rs
@@ -8,9 +8,15 @@ pub use innernet_shared::{
 };
 pub use wireguard_control::Backend;
 
+use crate::rest_client::RestClient;
 use anyhow::Error;
-use innernet_shared::wg;
-use std::path::Path;
+use innernet_shared::{
+    interface_config::{InterfaceConfig, InterfaceInfo, ServerInfo},
+    wg,
+};
+use std::path::PathBuf;
+use ureq::Agent;
+use wireguard_control::InterfaceName;
 
 pub mod data_store;
 pub mod interface;
@@ -25,19 +31,56 @@ pub const DEFAULT_DATA_DIR: &str = "/var/lib/innernet";
 #[cfg(target_os = "openbsd")]
 pub const DEFAULT_DATA_DIR: &str = "/var/db/innernet";
 
+/// [`Context`] contains data required by most public API functions.
+/// - [`Self::interface_info()`] produces an [`InterfaceInfo`] about an innernet interface.
+/// - [`Self::server_info()`] produces a [`ServerInfo`] about an innernet server.
+/// - [`Self::rest_client()`] produces a [`RestClient`] that can talk to an innernet server.
+pub struct Context {
+    config_dir: PathBuf,
+    interface: InterfaceName,
+    interface_config: InterfaceConfig,
+    agent: Agent,
+}
+
+impl Context {
+    // TODO(mbernat): Use a custom error type in the InterfaceConfig methods.
+    pub fn new(config_dir: PathBuf, interface: interface::InterfaceName) -> Result<Self, Error> {
+        let interface_config = InterfaceConfig::from_interface(&config_dir, &interface)?;
+        let agent = RestClient::create_agent();
+
+        Ok(Self {
+            config_dir,
+            interface,
+            interface_config,
+            agent,
+        })
+    }
+
+    pub fn interface_info(&self) -> &InterfaceInfo {
+        &self.interface_config.interface
+    }
+
+    pub fn server_info(&self) -> &ServerInfo {
+        &self.interface_config.server
+    }
+
+    pub fn rest_client(&self) -> RestClient<'_> {
+        RestClient::new(&self.agent, &self.interface_config.server)
+    }
+}
+
 /// Set the `listen_port`. `None` value unsets it.
 pub fn set_listen_port(
+    context: &mut Context,
     network_backend: Backend,
-    config_dir: &Path,
-    interface: &interface::InterfaceName,
-    config: &mut interface::InterfaceConfig,
     listen_port: Option<u16>,
 ) -> Result<(), Error> {
-    wg::set_listen_port(interface, listen_port, network_backend)?;
+    wg::set_listen_port(&context.interface, listen_port, network_backend)?;
     log::info!("the wireguard interface is updated");
 
+    let config = &mut context.interface_config;
     config.interface.listen_port = listen_port;
-    config.save(config_dir, interface)?;
+    config.save(&context.config_dir, &context.interface)?;
     log::info!("the config file is updated");
 
     Ok(())

--- a/client-core/src/lib.rs
+++ b/client-core/src/lib.rs
@@ -3,8 +3,8 @@
 //! This is a work in progress but the final goal is to match the `innernet` CLI API surface.
 
 pub use innernet_shared::{
-    interface_config::PeerInvitation, Cidr, CidrTree, Endpoint, HostsOpts, NatOpts, NetworkOpts,
-    Peer, WrappedIoError, DEFAULT_HOSTS_PATH,
+    interface_config::PeerInvitation, Cidr, CidrContents, CidrTree, Endpoint, HostsOpts, NatOpts,
+    NetworkOpts, Peer, WrappedIoError, DEFAULT_HOSTS_PATH,
 };
 pub use wireguard_control::Backend;
 

--- a/client-core/src/peer.rs
+++ b/client-core/src/peer.rs
@@ -1,51 +1,35 @@
 pub use innernet_shared::peer::NewPeerInfo;
 
-use crate::{
-    rest_client::{RestClient, RestError},
-    Cidr, Peer, PeerInvitation,
-};
+use crate::{rest_client::RestError, Cidr, Context, Peer, PeerInvitation};
 use anyhow::Result;
-use innernet_shared::{
-    interface_config::{InterfaceConfig, InterfaceInfo, ServerInfo},
-    CidrTree,
-};
-use std::path::Path;
+use innernet_shared::{interface_config::InterfaceInfo, CidrTree};
 use thiserror::Error;
-use wireguard_control::{InterfaceName, KeyPair};
+use wireguard_control::KeyPair;
 
 #[derive(Debug, Error)]
 pub enum CreatePeerError {
-    // TODO(mbernat): Use a custom error type in the InterfaceConfig methods.
-    #[error("Error accessing innernet interface config file: {0}")]
-    InterfaceConfigAccess(anyhow::Error),
     #[error("Error making a REST request: {0}")]
     RestRequest(#[from] RestError),
 }
 
 /// Create a new innernet [`Peer`] and a [`PeerInvitation`] they can use to join the network.
 pub fn create_peer(
-    config_dir: &Path,
-    interface: &InterfaceName,
+    context: &Context,
     existing_cidrs: &[Cidr],
-    existing_peers: &[Peer],
     new_peer_info: NewPeerInfo,
 ) -> Result<(Peer, PeerInvitation), CreatePeerError> {
-    let interface_config = InterfaceConfig::from_interface(config_dir, interface)
-        .map_err(CreatePeerError::InterfaceConfigAccess)?;
-    let rest_client = RestClient::new(&interface_config.server);
-
     let keypair = KeyPair::generate();
     let peer_contents = new_peer_info.into_peer_contents(&keypair);
-    let peer = rest_client.create_peer(&peer_contents)?;
+    let peer = context.rest_client().create_peer(&peer_contents)?;
 
     let cidr_tree = CidrTree::new(existing_cidrs);
     let address = &cidr_tree
         .ip_net_for(peer.ip)
         .expect("Peer's IpNet address to be valid because the peer was created successfully.");
-    let interface_info = InterfaceInfo::new(interface, &keypair, *address);
+    let interface_info = InterfaceInfo::new(&context.interface, &keypair, *address);
 
-    let server_peer = existing_peers.iter().find(|p| p.id == 1).unwrap();
-    let server_info = ServerInfo::new(server_peer, interface_config.server.internal_endpoint);
-
-    Ok((peer, PeerInvitation::new(interface_info, server_info)))
+    Ok((
+        peer,
+        PeerInvitation::new(interface_info, context.server_info().clone()),
+    ))
 }

--- a/client-core/src/rest_client.rs
+++ b/client-core/src/rest_client.rs
@@ -1,5 +1,5 @@
 use innernet_shared::{
-    interface_config::ServerInfo, Cidr, Peer, PeerContents, INNERNET_PUBKEY_HEADER,
+    interface_config::ServerInfo, Cidr, CidrContents, Peer, PeerContents, INNERNET_PUBKEY_HEADER,
 };
 use serde::{de::DeserializeOwned, Serialize};
 use std::{io, time::Duration};
@@ -27,6 +27,16 @@ impl<'a> RestClient<'a> {
         Self { agent, server }
     }
 
+    pub fn create_cidr(&self, cidr_contents: &CidrContents) -> Result<Cidr, RestError> {
+        let cidr = self.http_form("POST", "/admin/cidrs", cidr_contents)?;
+        Ok(cidr)
+    }
+
+    pub fn get_cidrs(&self) -> Result<Vec<Cidr>, RestError> {
+        let cidrs = self.http("GET", "/admin/cidrs")?;
+        Ok(cidrs)
+    }
+
     pub fn create_peer(&self, peer_contents: &PeerContents) -> Result<Peer, RestError> {
         let peer = self.http_form("POST", "/admin/peers", peer_contents)?;
         Ok(peer)
@@ -35,11 +45,6 @@ impl<'a> RestClient<'a> {
     pub fn get_peers(&self) -> Result<Vec<Peer>, RestError> {
         let peers = self.http("GET", "/admin/peers")?;
         Ok(peers)
-    }
-
-    pub fn get_cidrs(&self) -> Result<Vec<Cidr>, RestError> {
-        let cidrs = self.http("GET", "/admin/cidrs")?;
-        Ok(cidrs)
     }
 
     #[allow(clippy::result_large_err)]

--- a/client-core/src/rest_client.rs
+++ b/client-core/src/rest_client.rs
@@ -1,5 +1,6 @@
 use innernet_shared::{
-    interface_config::ServerInfo, Cidr, CidrContents, Peer, PeerContents, INNERNET_PUBKEY_HEADER,
+    interface_config::ServerInfo, Cidr, CidrContents, Peer, PeerContents, State,
+    INNERNET_PUBKEY_HEADER,
 };
 use serde::{de::DeserializeOwned, Serialize};
 use std::{io, time::Duration};
@@ -11,20 +12,23 @@ use ureq::{Agent, AgentBuilder};
 /// We recommend to use the high level API (like [`Self::create_peer()`]) when possible and fall
 /// back on the low level [`Self::http()`] and [`Self::http_form()`] otherwise.
 pub struct RestClient<'a> {
-    agent: Agent,
+    agent: &'a Agent,
     server: &'a ServerInfo,
 }
 
 impl<'a> RestClient<'a> {
-    /// Create a [`Self`] to communicate with an innernet server described by [`ServerInfo`].
-    pub fn new(server: &'a ServerInfo) -> Self {
-        let agent = AgentBuilder::new()
+    /// Create a [`RestClient`] to communicate with an innernet server described by [`ServerInfo`].
+    pub fn new(agent: &'a Agent, server: &'a ServerInfo) -> Self {
+        Self { agent, server }
+    }
+
+    pub fn create_agent() -> Agent {
+        AgentBuilder::new()
             // Some platforms (e.g. OpenBSD) can take longer to complete the first WireGuard
             // handshake, hence a lower timeout value could result in an unwarranted failure
             .timeout(Duration::from_secs(10))
             .redirects(0)
-            .build();
-        Self { agent, server }
+            .build()
     }
 
     pub fn create_cidr(&self, cidr_contents: &CidrContents) -> Result<Cidr, RestError> {
@@ -45,6 +49,11 @@ impl<'a> RestClient<'a> {
     pub fn get_peers(&self) -> Result<Vec<Peer>, RestError> {
         let peers = self.http("GET", "/admin/peers")?;
         Ok(peers)
+    }
+
+    pub fn get_state(&self) -> Result<State, RestError> {
+        let state = self.http("GET", "/user/state")?;
+        Ok(state)
     }
 
     #[allow(clippy::result_large_err)]

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -8,8 +8,8 @@ use innernet_client_core::{
     data_store::DataStore,
     interface::{fetch, redeem_invite},
     peer::create_peer,
-    rest_client::{RestClient, RestError},
-    DEFAULT_CONFIG_DIR, DEFAULT_DATA_DIR,
+    rest_client::RestError,
+    Context, DEFAULT_CONFIG_DIR, DEFAULT_DATA_DIR,
 };
 use innernet_shared::{
     interface_config::InterfaceConfig, prompts, wg, wg::PeerInfoExt, AddCidrOpts,
@@ -281,16 +281,16 @@ fn install(
 
     let interface_name = interface_name.parse()?;
     redeem_invite(&opts.config_dir, &opts.network, &interface_name, config)?;
+    let context = Context::new(opts.config_dir.clone(), interface_name)?;
 
     let mut fetch_success = false;
     for _ in 0..3 {
         if fetch(
-            &opts.config_dir,
+            &context,
             &opts.data_dir,
             &opts.network,
             hosts_opts,
             nat_opts,
-            &interface_name,
             true,
         )
         .is_ok()
@@ -389,13 +389,14 @@ fn up(
         };
 
         for interface in interfaces {
+            let context = Context::new(opts.config_dir.clone(), *interface)?;
+
             fetch(
-                &opts.config_dir,
+                &context,
                 &opts.data_dir,
                 &opts.network,
                 &hosts_opts,
                 nat_opts,
-                &interface,
                 true,
             )?;
         }
@@ -449,15 +450,14 @@ fn uninstall(interface: &InterfaceName, opts: &Opts, yes: bool) -> Result<(), Er
 }
 
 fn add_cidr(interface: &InterfaceName, opts: &Opts, sub_opts: AddCidrOpts) -> Result<(), Error> {
-    let InterfaceConfig { server, .. } =
-        InterfaceConfig::from_interface(&opts.config_dir, interface)?;
+    let context = Context::new(opts.config_dir.clone(), *interface)?;
+
     log::info!("Fetching CIDRs");
-    let rest_client = RestClient::new(&server);
-    let cidrs: Vec<Cidr> = rest_client.get_cidrs()?;
+    let cidrs: Vec<Cidr> = context.rest_client().get_cidrs()?;
 
     if let Some(cidr_request) = prompts::add_cidr(&cidrs, &sub_opts)? {
         log::info!("Creating CIDR...");
-        let cidr: Cidr = rest_client.create_cidr(&cidr_request)?;
+        let cidr: Cidr = context.rest_client().create_cidr(&cidr_request)?;
 
         eprintdoc!(
             "
@@ -482,12 +482,10 @@ fn rename_cidr(
     opts: &Opts,
     sub_opts: RenameCidrOpts,
 ) -> Result<(), Error> {
-    let InterfaceConfig { server, .. } =
-        InterfaceConfig::from_interface(&opts.config_dir, interface)?;
-    let rest_client = RestClient::new(&server);
+    let context = Context::new(opts.config_dir.clone(), *interface)?;
 
     log::info!("Fetching CIDRs");
-    let cidrs: Vec<Cidr> = rest_client.http("GET", "/admin/cidrs")?;
+    let cidrs: Vec<Cidr> = context.rest_client().http("GET", "/admin/cidrs")?;
 
     if let Some((cidr_request, old_name)) = prompts::rename_cidr(&cidrs, &sub_opts)? {
         log::info!("Renaming CIDR...");
@@ -498,7 +496,11 @@ fn rename_cidr(
             .ok_or_else(|| anyhow!("CIDR not found."))?
             .id;
 
-        rest_client.http_form::<_, ()>("PUT", &format!("/admin/cidrs/{id}"), cidr_request)?;
+        context.rest_client().http_form::<_, ()>(
+            "PUT",
+            &format!("/admin/cidrs/{id}"),
+            cidr_request,
+        )?;
         log::info!("CIDR renamed.");
     } else {
         log::info!("Exited without renaming CIDR.");
@@ -512,19 +514,21 @@ fn delete_cidr(
     opts: &Opts,
     sub_opts: DeleteCidrOpts,
 ) -> Result<(), Error> {
-    let InterfaceConfig { server, .. } =
-        InterfaceConfig::from_interface(&opts.config_dir, interface)?;
-    println!("Fetching eligible CIDRs");
-    let rest_client = RestClient::new(&server);
-    let cidrs: Vec<Cidr> = rest_client.http("GET", "/admin/cidrs")?;
-    let peers: Vec<Peer> = rest_client.http("GET", "/admin/peers")?;
+    let context = Context::new(opts.config_dir.clone(), *interface)?;
+
+    log::info!("Fetching CIDRs");
+    let cidrs: Vec<Cidr> = context.rest_client().http("GET", "/admin/cidrs")?;
+    log::info!("Fetching peers");
+    let peers: Vec<Peer> = context.rest_client().http("GET", "/admin/peers")?;
 
     let cidr_id = prompts::delete_cidr(&cidrs, &peers, &sub_opts)?;
 
-    println!("Deleting CIDR...");
-    rest_client.http::<()>("DELETE", &format!("/admin/cidrs/{cidr_id}"))?;
+    log::info!("Deleting CIDR...");
+    context
+        .rest_client()
+        .http::<()>("DELETE", &format!("/admin/cidrs/{cidr_id}"))?;
 
-    println!("CIDR deleted.");
+    log::info!("CIDR deleted.");
 
     Ok(())
 }
@@ -545,22 +549,19 @@ fn list_cidrs(interface: &InterfaceName, opts: &Opts, tree: bool) -> Result<(), 
 }
 
 fn add_peer(interface: &InterfaceName, opts: &Opts, sub_opts: AddPeerOpts) -> Result<(), Error> {
-    let InterfaceConfig { server, .. } =
-        InterfaceConfig::from_interface(&opts.config_dir, interface)?;
-    let rest_client = RestClient::new(&server);
+    let context = Context::new(opts.config_dir.clone(), *interface)?;
 
     log::info!("Fetching CIDRs");
-    let cidrs = rest_client.get_cidrs()?;
+    let cidrs = context.rest_client().get_cidrs()?;
     log::info!("Fetching peers");
-    let peers = rest_client.get_peers()?;
+    let peers = context.rest_client().get_peers()?;
     let cidr_tree = CidrTree::new(&cidrs[..]);
 
     if let Some((new_peer_info, target_path)) =
         prompts::gather_new_peer_info(&peers, &cidr_tree, &sub_opts)?
     {
         log::info!("Creating peer...");
-        let (peer, invitation) =
-            create_peer(&opts.config_dir, interface, &cidrs, &peers, new_peer_info)?;
+        let (peer, invitation) = create_peer(&context, &cidrs, new_peer_info)?;
 
         invitation.save_new(&target_path)?;
         prompts::print_invitation_info(&peer, &target_path);
@@ -576,12 +577,10 @@ fn rename_peer(
     opts: &Opts,
     sub_opts: RenamePeerOpts,
 ) -> Result<(), Error> {
-    let InterfaceConfig { server, .. } =
-        InterfaceConfig::from_interface(&opts.config_dir, interface)?;
-    let rest_client = RestClient::new(&server);
+    let context = Context::new(opts.config_dir.clone(), *interface)?;
 
     log::info!("Fetching peers");
-    let peers: Vec<Peer> = rest_client.http("GET", "/admin/peers")?;
+    let peers: Vec<Peer> = context.rest_client().http("GET", "/admin/peers")?;
 
     if let Some((peer_request, old_name)) = prompts::rename_peer(&peers, &sub_opts)? {
         log::info!("Renaming peer...");
@@ -593,7 +592,11 @@ fn rename_peer(
             .next()
             .ok_or_else(|| anyhow!("Peer not found."))?;
 
-        rest_client.http_form::<_, ()>("PUT", &format!("/admin/peers/{id}"), peer_request)?;
+        context.rest_client().http_form::<_, ()>(
+            "PUT",
+            &format!("/admin/peers/{id}"),
+            peer_request,
+        )?;
         log::info!("Peer renamed.");
     } else {
         log::info!("exited without renaming peer.");
@@ -608,17 +611,17 @@ fn enable_or_disable_peer(
     sub_opts: EnableDisablePeerOpts,
     enable: bool,
 ) -> Result<(), Error> {
-    let InterfaceConfig { server, .. } =
-        InterfaceConfig::from_interface(&opts.config_dir, interface)?;
-    let rest_client = RestClient::new(&server);
+    let context = Context::new(opts.config_dir.clone(), *interface)?;
 
     log::info!("Fetching peers.");
-    let peers: Vec<Peer> = rest_client.http("GET", "/admin/peers")?;
+    let peers: Vec<Peer> = context.rest_client().http("GET", "/admin/peers")?;
 
     if let Some(peer) = prompts::enable_or_disable_peer(&peers[..], &sub_opts, enable)? {
         let Peer { id, mut contents } = peer;
         contents.is_disabled = !enable;
-        rest_client.http_form::<_, ()>("PUT", &format!("/admin/peers/{id}"), contents)?;
+        context
+            .rest_client()
+            .http_form::<_, ()>("PUT", &format!("/admin/peers/{id}"), contents)?;
     } else {
         log::info!("exiting without enabling or disabling peer.");
     }
@@ -631,12 +634,10 @@ fn add_association(
     opts: &Opts,
     sub_opts: AddDeleteAssociationOpts,
 ) -> Result<(), Error> {
-    let InterfaceConfig { server, .. } =
-        InterfaceConfig::from_interface(&opts.config_dir, interface)?;
-    let rest_client = RestClient::new(&server);
+    let context = Context::new(opts.config_dir.clone(), *interface)?;
 
     log::info!("Fetching CIDRs");
-    let cidrs: Vec<Cidr> = rest_client.http("GET", "/admin/cidrs")?;
+    let cidrs: Vec<Cidr> = context.rest_client().http("GET", "/admin/cidrs")?;
 
     let association = if let (Some(ref cidr1), Some(ref cidr2)) = (&sub_opts.cidr1, &sub_opts.cidr2)
     {
@@ -656,7 +657,7 @@ fn add_association(
         return Ok(());
     };
 
-    rest_client.http_form::<_, ()>(
+    context.rest_client().http_form::<_, ()>(
         "POST",
         "/admin/associations",
         AssociationContents {
@@ -673,19 +674,20 @@ fn delete_association(
     opts: &Opts,
     sub_opts: AddDeleteAssociationOpts,
 ) -> Result<(), Error> {
-    let InterfaceConfig { server, .. } =
-        InterfaceConfig::from_interface(&opts.config_dir, interface)?;
-    let rest_client = RestClient::new(&server);
+    let context = Context::new(opts.config_dir.clone(), *interface)?;
 
     log::info!("Fetching CIDRs");
-    let cidrs: Vec<Cidr> = rest_client.http("GET", "/admin/cidrs")?;
+    let cidrs: Vec<Cidr> = context.rest_client().http("GET", "/admin/cidrs")?;
     log::info!("Fetching associations");
-    let associations: Vec<Association> = rest_client.http("GET", "/admin/associations")?;
+    let associations: Vec<Association> =
+        context.rest_client().http("GET", "/admin/associations")?;
 
     if let Some(association) =
         prompts::delete_association(&associations[..], &cidrs[..], &sub_opts)?
     {
-        rest_client.http::<()>("DELETE", &format!("/admin/associations/{}", association.id))?;
+        context
+            .rest_client()
+            .http::<()>("DELETE", &format!("/admin/associations/{}", association.id))?;
     } else {
         log::info!("exiting without adding association.");
     }
@@ -694,14 +696,13 @@ fn delete_association(
 }
 
 fn list_associations(interface: &InterfaceName, opts: &Opts) -> Result<(), Error> {
-    let InterfaceConfig { server, .. } =
-        InterfaceConfig::from_interface(&opts.config_dir, interface)?;
-    let rest_client = RestClient::new(&server);
+    let context = Context::new(opts.config_dir.clone(), *interface)?;
 
     log::info!("Fetching CIDRs");
-    let cidrs: Vec<Cidr> = rest_client.http("GET", "/admin/cidrs")?;
+    let cidrs: Vec<Cidr> = context.rest_client().http("GET", "/admin/cidrs")?;
     log::info!("Fetching associations");
-    let associations: Vec<Association> = rest_client.http("GET", "/admin/associations")?;
+    let associations: Vec<Association> =
+        context.rest_client().http("GET", "/admin/associations")?;
 
     for association in associations {
         println!(
@@ -730,17 +731,11 @@ fn set_listen_port(
     opts: &Opts,
     sub_opts: ListenPortOpts,
 ) -> Result<(), Error> {
-    let mut config = InterfaceConfig::from_interface(&opts.config_dir, interface)?;
+    let mut context = Context::new(opts.config_dir.clone(), *interface)?;
 
-    let listen_port = prompts::set_listen_port(&config.interface, sub_opts)?;
+    let listen_port = prompts::set_listen_port(context.interface_info(), sub_opts)?;
     if let Some(listen_port) = listen_port {
-        innernet_client_core::set_listen_port(
-            opts.network.backend,
-            &opts.config_dir,
-            interface,
-            &mut config,
-            listen_port,
-        )?;
+        innernet_client_core::set_listen_port(&mut context, opts.network.backend, listen_port)?;
     } else {
         log::info!("exiting without updating the listen port.");
     }
@@ -753,13 +748,13 @@ fn override_endpoint(
     opts: &Opts,
     sub_opts: OverrideEndpointOpts,
 ) -> Result<(), Error> {
-    let config = InterfaceConfig::from_interface(&opts.config_dir, interface)?;
+    let context = Context::new(opts.config_dir.clone(), *interface)?;
 
     let endpoint_contents = if sub_opts.unset {
         prompt_unset_override_endpoint(&sub_opts)?.then_some(EndpointContents::Unset)
     } else {
-        let server_capabilities = get_server_capabilities(&config)?;
-        let port = match config.interface.listen_port {
+        let server_capabilities = get_server_capabilities(&context)?;
+        let port = match context.interface_info().listen_port {
             Some(port) => port,
             None => bail!("you need to set a listen port with set-listen-port before overriding the endpoint (otherwise port randomization on the interface would make it useless).")
         };
@@ -769,7 +764,9 @@ fn override_endpoint(
 
     if let Some(contents) = endpoint_contents {
         log::info!("requesting endpoint update...");
-        RestClient::new(&config.server).http_form::<_, ()>("PUT", "/user/endpoint", contents)?;
+        context
+            .rest_client()
+            .http_form::<_, ()>("PUT", "/user/endpoint", contents)?;
         log::info!(
             "endpoint override {}",
             if sub_opts.unset { "unset" } else { "set" }
@@ -820,10 +817,9 @@ fn prompt_unset_override_endpoint(args: &OverrideEndpointOpts) -> Result<bool, E
         || prompts::confirm("Unset external endpoint to enable automatic endpoint discovery?")?)
 }
 
-fn get_server_capabilities(config: &InterfaceConfig) -> Result<ServerCapabilities, Error> {
-    let rest_client = RestClient::new(&config.server);
+fn get_server_capabilities(context: &Context) -> Result<ServerCapabilities, Error> {
     let maybe_info: Result<ServerCapabilities, RestError> =
-        rest_client.http("GET", "/user/capabilities");
+        context.rest_client().http("GET", "/user/capabilities");
     match maybe_info {
         Ok(info) => Ok(info),
         Err(e) => {
@@ -1062,15 +1058,8 @@ fn run(opts: &Opts) -> Result<(), Error> {
             hosts,
             nat,
         } => {
-            fetch(
-                &opts.config_dir,
-                &opts.data_dir,
-                &opts.network,
-                &hosts,
-                &nat,
-                &interface,
-                false,
-            )?;
+            let context = Context::new(opts.config_dir.clone(), *interface)?;
+            fetch(&context, &opts.data_dir, &opts.network, &hosts, &nat, false)?;
         },
         Command::Up {
             interface,

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -453,11 +453,11 @@ fn add_cidr(interface: &InterfaceName, opts: &Opts, sub_opts: AddCidrOpts) -> Re
         InterfaceConfig::from_interface(&opts.config_dir, interface)?;
     log::info!("Fetching CIDRs");
     let rest_client = RestClient::new(&server);
-    let cidrs: Vec<Cidr> = rest_client.http("GET", "/admin/cidrs")?;
+    let cidrs: Vec<Cidr> = rest_client.get_cidrs()?;
 
     if let Some(cidr_request) = prompts::add_cidr(&cidrs, &sub_opts)? {
         log::info!("Creating CIDR...");
-        let cidr: Cidr = rest_client.http_form("POST", "/admin/cidrs", cidr_request)?;
+        let cidr: Cidr = rest_client.create_cidr(&cidr_request)?;
 
         eprintdoc!(
             "

--- a/shared/src/prompts.rs
+++ b/shared/src/prompts.rs
@@ -96,11 +96,7 @@ pub fn add_cidr(cidrs: &[Cidr], request: &AddCidrOpts) -> Result<Option<CidrCont
         input("CIDR", Prefill::None)?
     };
 
-    let cidr_request = CidrContents {
-        name: name.to_string(),
-        cidr,
-        parent: Some(parent_cidr.id),
-    };
+    let cidr_request = CidrContents::new(name, cidr, parent_cidr);
 
     Ok(
         if request.yes || confirm(&format!("Create CIDR \"{}\"?", cidr_request.name))? {

--- a/shared/src/prompts.rs
+++ b/shared/src/prompts.rs
@@ -96,7 +96,7 @@ pub fn add_cidr(cidrs: &[Cidr], request: &AddCidrOpts) -> Result<Option<CidrCont
         input("CIDR", Prefill::None)?
     };
 
-    let cidr_request = CidrContents::new(name, cidr, parent_cidr);
+    let cidr_request = CidrContents::new(name.to_string(), cidr, parent_cidr);
 
     Ok(
         if request.yes || confirm(&format!("Create CIDR \"{}\"?", cidr_request.name))? {

--- a/shared/src/types.rs
+++ b/shared/src/types.rs
@@ -215,9 +215,9 @@ pub struct CidrContents {
 }
 
 impl CidrContents {
-    pub fn new(name: Hostname, cidr: IpNet, parent: &Cidr) -> Self {
+    pub fn new(name: String, cidr: IpNet, parent: &Cidr) -> Self {
         Self {
-            name: name.to_string(),
+            name,
             cidr,
             parent: Some(parent.id),
         }

--- a/shared/src/types.rs
+++ b/shared/src/types.rs
@@ -214,6 +214,16 @@ pub struct CidrContents {
     pub parent: Option<i64>,
 }
 
+impl CidrContents {
+    pub fn new(name: Hostname, cidr: IpNet, parent: &Cidr) -> Self {
+        Self {
+            name: name.to_string(),
+            cidr,
+            parent: Some(parent.id),
+        }
+    }
+}
+
 impl Deref for CidrContents {
     type Target = IpNet;
 


### PR DESCRIPTION
- This should make it easier to use the core APIs in a concise and a unified way.
- For the moment it takes care about the interface config and the Rest client but we should also integrate the data store and maybe other things.
- On top of #391