### PR TITLE
Fix reverse path filtering documentation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,10 @@ If you're running a service on innernet, there are some important security consi
 Strict RPF prevents packets from _other_ interfaces from having internal source IP addresses. This is _not_ the default on Linux, even though it is the right choice for 99.99% of situations. You can enable it by adding the following to a `/etc/sysctl.d/60-network-security.conf`:
 
 ```
-net.ipv4.conf.all.rp_filter=1
-net.ipv4.conf.default.rp_filter=1
+net.ipv4.conf.all.rp_filter = 1
+net.ipv4.conf.default.rp_filter = 1
+# also apply to existing interfaces:
+net.ipv4.conf.*.rp_filter = 1
 ```
 
 ### Bind to the WireGuard device

--- a/README.md
+++ b/README.md
@@ -170,7 +170,10 @@ Strict RPF prevents packets from _other_ interfaces from having internal source 
 ```
 net.ipv4.conf.all.rp_filter = 1
 net.ipv4.conf.default.rp_filter = 1
-# also apply to existing interfaces:
+
+# Also apply to interfaces that exist at the time this sysctl is applied, as they might have been
+# created with value 2 (loose), which takes precedence even when all.rp_filter is 1.
+# Note that using the * match does not apply to the special `all` and `default` knobs.
 net.ipv4.conf.*.rp_filter = 1
 ```
 


### PR DESCRIPTION
- relates to https://github.com/tonarino/innernet/issues/26
- sibling to (tonari internal PR): https://github.com/tonarino/portal/pull/6166

By chance I've found out it is not sufficient to set `rp_filter` just for `all` and `default`, that doesn't apply to _existing_ devices. Update the advice.

I've also checked and `*` does **not** apply to `all` and `default`, so keep these.