### PR TITLE
Client override endpoint

### DIFF
--- a/client-core/src/data_store.rs
+++ b/client-core/src/data_store.rs
@@ -19,7 +19,7 @@ struct FileBackedData<T> {
     contents: T,
 }
 
-impl<T: Default + DeserializeOwned> FileBackedData<T> {
+impl<T: Default + DeserializeOwned + Serialize> FileBackedData<T> {
     fn open_with_path<P: AsRef<Path>>(path: P, create: bool) -> Result<Self, WrappedIoError> {
         let path = path.as_ref();
         let is_existing_file = path.exists();
@@ -42,6 +42,14 @@ impl<T: Default + DeserializeOwned> FileBackedData<T> {
         let contents = serde_json::from_str(&json).unwrap_or_else(|_| T::default());
 
         Ok(Self { file, contents })
+    }
+
+    fn write(&mut self) -> Result<(), io::Error> {
+        self.file.rewind()?;
+        self.file.set_len(0)?;
+        self.file
+            .write_all(serde_json::to_string_pretty(&self.contents)?.as_bytes())?;
+        Ok(())
     }
 }
 
@@ -102,12 +110,11 @@ impl DataStore {
 
     /// Produce the path "`data_dir`/`interface`.peer-endpoint-overrides.json".
     pub fn get_peer_endpoint_overrides_path(data_dir: &Path, interface: &InterfaceName) -> PathBuf {
-        let file_name = format!("{interface}.peer-endpoint-overrides");
-        data_dir.join(file_name).with_extension("json")
-    }
+        let file_name = format!("{interface}.peer-endpoint-overrides.json");
 
-    pub fn peers_and_cidrs_file_exists(data_dir: &Path, interface: &InterfaceName) -> bool {
-        Self::get_peers_and_cidrs_path(data_dir, interface).exists()
+        // Warning - if you use `.with_extension("json")` here instead of inlining it above,
+        //           it will result in `{interface}.json` which is undesirable.
+        data_dir.join(file_name)
     }
 
     fn _open(
@@ -116,13 +123,16 @@ impl DataStore {
         create: bool,
     ) -> Result<Self, WrappedIoError> {
         ensure_dirs_exist(&[data_dir])?;
+
         let peers_and_cidrs = FileBackedData::open_with_path(
             Self::get_peers_and_cidrs_path(data_dir, interface),
             create,
         )?;
+
         let peer_endpoint_overrides = FileBackedData::open_with_path(
             Self::get_peer_endpoint_overrides_path(data_dir, interface),
-            create,
+            // Always create the peer overrides file if it doesn't exist.
+            true,
         )?;
 
         Ok(Self {
@@ -131,12 +141,12 @@ impl DataStore {
         })
     }
 
-    /// Open the data store residing at "`data_dir`/`interface`.json".
+    /// Open the data store residing in the "`data_dir`" directory.
     pub fn open(data_dir: &Path, interface: &InterfaceName) -> Result<Self, WrappedIoError> {
         Self::_open(data_dir, interface, false)
     }
 
-    /// Open or create the data store residing at "`data_dir`/`interface`.json".
+    /// Open or create the data store residing in the "`data_dir`" directory.
     pub fn open_or_create(
         data_dir: &Path,
         interface: &InterfaceName,
@@ -212,11 +222,7 @@ impl DataStore {
     }
 
     fn write_peers_and_cidrs(&mut self) -> Result<(), io::Error> {
-        self.peers_and_cidrs.file.rewind()?;
-        self.peers_and_cidrs.file.set_len(0)?;
-        self.peers_and_cidrs
-            .file
-            .write_all(serde_json::to_string_pretty(&self.peers_and_cidrs.contents)?.as_bytes())?;
+        self.peers_and_cidrs.write()?;
         Ok(())
     }
 
@@ -256,11 +262,7 @@ impl DataStore {
     }
 
     pub fn write_peer_endpoint_overrides(&mut self) -> Result<(), io::Error> {
-        self.peer_endpoint_overrides.file.rewind()?;
-        self.peer_endpoint_overrides.file.set_len(0)?;
-        self.peer_endpoint_overrides.file.write_all(
-            serde_json::to_string_pretty(&self.peer_endpoint_overrides.contents)?.as_bytes(),
-        )?;
+        self.peer_endpoint_overrides.write()?;
         Ok(())
     }
 

--- a/client-core/src/data_store.rs
+++ b/client-core/src/data_store.rs
@@ -159,6 +159,15 @@ impl DataStore {
         }
     }
 
+    pub fn endpoint_override_for_peer(&self, peer_ip: IpAddr) -> Option<SocketAddr> {
+        match &self.contents {
+            Contents::V1 {
+                local_endpoint_overrides,
+                ..
+            } => local_endpoint_overrides.get(&peer_ip).copied(),
+        }
+    }
+
     fn set_cidrs(&mut self, new_cidrs: Vec<Cidr>) {
         match &mut self.contents {
             Contents::V1 { ref mut cidrs, .. } => *cidrs = new_cidrs,

--- a/client-core/src/data_store.rs
+++ b/client-core/src/data_store.rs
@@ -198,7 +198,7 @@ impl DataStore {
         }
     }
 
-    fn write(&mut self) -> Result<(), io::Error> {
+    pub fn write(&mut self) -> Result<(), io::Error> {
         self.file.rewind()?;
         self.file.set_len(0)?;
         self.file

--- a/client-core/src/data_store.rs
+++ b/client-core/src/data_store.rs
@@ -1,11 +1,13 @@
 use anyhow::{bail, Error};
-use innernet_shared::{chmod, ensure_dirs_exist, Cidr, IoErrorContext, Peer, WrappedIoError};
+use innernet_shared::{
+    chmod, ensure_dirs_exist, Cidr, Endpoint, IoErrorContext, Peer, WrappedIoError,
+};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     fs::{File, OpenOptions},
     io::{self, Read, Seek, Write},
-    net::{IpAddr, SocketAddr},
+    net::IpAddr,
     path::{Path, PathBuf},
 };
 use wireguard_control::InterfaceName;
@@ -27,7 +29,7 @@ enum Contents {
         peers: Vec<Peer>,
         cidrs: Vec<Cidr>,
         #[serde(default)]
-        local_endpoint_overrides: HashMap<IpAddr, SocketAddr>,
+        local_endpoint_overrides: HashMap<IpAddr, Endpoint>,
     },
 }
 
@@ -148,23 +150,45 @@ impl DataStore {
         }
     }
 
-    pub fn local_endpoint_overrides(&self) -> impl Iterator<Item = (IpAddr, SocketAddr)> + '_ {
+    pub fn local_endpoint_overrides(&self) -> impl Iterator<Item = (IpAddr, Endpoint)> + '_ {
         match &self.contents {
             Contents::V1 {
                 local_endpoint_overrides,
                 ..
             } => local_endpoint_overrides
                 .iter()
-                .map(|(ip, socket)| (*ip, *socket)),
+                .map(|(ip, socket)| (*ip, socket.clone())),
         }
     }
 
-    pub fn endpoint_override_for_peer(&self, peer_ip: IpAddr) -> Option<SocketAddr> {
+    pub fn endpoint_override_for_peer(&self, peer_ip: IpAddr) -> Option<Endpoint> {
         match &self.contents {
             Contents::V1 {
                 local_endpoint_overrides,
                 ..
-            } => local_endpoint_overrides.get(&peer_ip).copied(),
+            } => local_endpoint_overrides.get(&peer_ip).cloned(),
+        }
+    }
+
+    pub fn override_endpoint_for_peer(&mut self, peer_ip: IpAddr, endpoint: Endpoint) {
+        match &mut self.contents {
+            Contents::V1 {
+                local_endpoint_overrides,
+                ..
+            } => {
+                local_endpoint_overrides.insert(peer_ip, endpoint);
+            },
+        }
+    }
+
+    pub fn unset_endpoint_for_peer(&mut self, peer_ip: IpAddr) {
+        match &mut self.contents {
+            Contents::V1 {
+                local_endpoint_overrides,
+                ..
+            } => {
+                local_endpoint_overrides.remove(&peer_ip);
+            },
         }
     }
 

--- a/client-core/src/data_store.rs
+++ b/client-core/src/data_store.rs
@@ -2,8 +2,10 @@ use anyhow::{bail, Error};
 use innernet_shared::{chmod, ensure_dirs_exist, Cidr, IoErrorContext, Peer, WrappedIoError};
 use serde::{Deserialize, Serialize};
 use std::{
+    collections::HashMap,
     fs::{File, OpenOptions},
     io::{self, Read, Seek, Write},
+    net::{IpAddr, SocketAddr},
     path::{Path, PathBuf},
 };
 use wireguard_control::InterfaceName;
@@ -21,7 +23,12 @@ pub struct DataStore {
 #[serde(tag = "version")]
 enum Contents {
     #[serde(rename = "1")]
-    V1 { peers: Vec<Peer>, cidrs: Vec<Cidr> },
+    V1 {
+        peers: Vec<Peer>,
+        cidrs: Vec<Cidr>,
+        #[serde(default)]
+        local_endpoint_overrides: HashMap<IpAddr, SocketAddr>,
+    },
 }
 
 impl DataStore {
@@ -47,6 +54,7 @@ impl DataStore {
         let contents = serde_json::from_str(&json).unwrap_or_else(|_| Contents::V1 {
             peers: vec![],
             cidrs: vec![],
+            local_endpoint_overrides: HashMap::new(),
         });
 
         Ok(Self { file, contents })
@@ -137,6 +145,17 @@ impl DataStore {
     pub fn cidrs(&self) -> &[Cidr] {
         match &self.contents {
             Contents::V1 { cidrs, .. } => cidrs,
+        }
+    }
+
+    pub fn local_endpoint_overrides(&self) -> impl Iterator<Item = (IpAddr, SocketAddr)> + '_ {
+        match &self.contents {
+            Contents::V1 {
+                local_endpoint_overrides,
+                ..
+            } => local_endpoint_overrides
+                .iter()
+                .map(|(ip, socket)| (*ip, *socket)),
         }
     }
 

--- a/client-core/src/data_store.rs
+++ b/client-core/src/data_store.rs
@@ -1,8 +1,9 @@
 use anyhow::{bail, Error};
+use colored::Colorize;
 use innernet_shared::{
     chmod, ensure_dirs_exist, Cidr, Endpoint, IoErrorContext, Peer, WrappedIoError,
 };
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
     fs::{File, OpenOptions},
@@ -12,30 +13,13 @@ use std::{
 };
 use wireguard_control::InterfaceName;
 
-/// File-backed storage of [`Peer`]s and [`Cidr`]s.
-///
-/// The file is stored at [`Self::get_path()`].
 #[derive(Debug)]
-pub struct DataStore {
+struct FileBackedData<T> {
     file: File,
-    contents: Contents,
+    contents: T,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(tag = "version")]
-enum Contents {
-    #[serde(rename = "1")]
-    V1 {
-        peers: Vec<Peer>,
-        cidrs: Vec<Cidr>,
-
-        /// This field was added in innernet 1.8, but the change is backwards-compatible, we thus kept it in v1
-        #[serde(default)]
-        peer_endpoint_overrides: BTreeMap<IpAddr, Endpoint>,
-    },
-}
-
-impl DataStore {
+impl<T: Default + DeserializeOwned> FileBackedData<T> {
     fn open_with_path<P: AsRef<Path>>(path: P, create: bool) -> Result<Self, WrappedIoError> {
         let path = path.as_ref();
         let is_existing_file = path.exists();
@@ -55,18 +39,75 @@ impl DataStore {
 
         let mut json = String::new();
         file.read_to_string(&mut json).with_path(path)?;
-        let contents = serde_json::from_str(&json).unwrap_or_else(|_| Contents::V1 {
-            peers: vec![],
-            cidrs: vec![],
-            peer_endpoint_overrides: BTreeMap::new(),
-        });
+        let contents = serde_json::from_str(&json).unwrap_or_else(|_| T::default());
 
         Ok(Self { file, contents })
     }
+}
 
+#[derive(Debug)]
+pub struct DataStore {
+    /// File-backed storage of [`Peer`]s and [`Cidr`]s.
+    ///
+    /// The file is stored at [`Self::get_peers_and_cidrs_path()`].
+    peers_and_cidrs: FileBackedData<PeersAndCidrs>,
+
+    /// File-backed storage of [`PeerEndpointOverrides`]s.
+    ///
+    /// The file is stored at [`Self::get_peer_endpoint_overrides_path()`].
+    peer_endpoint_overrides: FileBackedData<PeerEndpointOverrides>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "version")]
+enum PeersAndCidrs {
+    #[serde(rename = "1")]
+    V1 { peers: Vec<Peer>, cidrs: Vec<Cidr> },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "version")]
+enum PeerEndpointOverrides {
+    #[serde(rename = "1")]
+    V1 {
+        /// This field was added in innernet 1.8, but the change is
+        /// backwards-compatible, we thus kept it in v1
+        #[serde(default)]
+        peer_endpoint_overrides: BTreeMap<IpAddr, Endpoint>,
+    },
+}
+
+impl Default for PeersAndCidrs {
+    fn default() -> Self {
+        Self::V1 {
+            peers: vec![],
+            cidrs: vec![],
+        }
+    }
+}
+
+impl Default for PeerEndpointOverrides {
+    fn default() -> Self {
+        Self::V1 {
+            peer_endpoint_overrides: BTreeMap::new(),
+        }
+    }
+}
+
+impl DataStore {
     /// Produce the path "`data_dir`/`interface`.json".
-    pub fn get_path(data_dir: &Path, interface: &InterfaceName) -> PathBuf {
+    pub fn get_peers_and_cidrs_path(data_dir: &Path, interface: &InterfaceName) -> PathBuf {
         data_dir.join(interface.to_string()).with_extension("json")
+    }
+
+    /// Produce the path "`data_dir`/`interface`.peer-endpoint-overrides.json".
+    pub fn get_peer_endpoint_overrides_path(data_dir: &Path, interface: &InterfaceName) -> PathBuf {
+        let file_name = format!("{interface}.peer-endpoint-overrides");
+        data_dir.join(file_name).with_extension("json")
+    }
+
+    pub fn peers_and_cidrs_file_exists(data_dir: &Path, interface: &InterfaceName) -> bool {
+        Self::get_peers_and_cidrs_path(data_dir, interface).exists()
     }
 
     fn _open(
@@ -75,7 +116,19 @@ impl DataStore {
         create: bool,
     ) -> Result<Self, WrappedIoError> {
         ensure_dirs_exist(&[data_dir])?;
-        Self::open_with_path(Self::get_path(data_dir, interface), create)
+        let peers_and_cidrs = FileBackedData::open_with_path(
+            Self::get_peers_and_cidrs_path(data_dir, interface),
+            create,
+        )?;
+        let peer_endpoint_overrides = FileBackedData::open_with_path(
+            Self::get_peer_endpoint_overrides_path(data_dir, interface),
+            create,
+        )?;
+
+        Ok(Self {
+            peers_and_cidrs,
+            peer_endpoint_overrides,
+        })
     }
 
     /// Open the data store residing at "`data_dir`/`interface`.json".
@@ -106,14 +159,14 @@ impl DataStore {
     ) -> Result<(), Error> {
         self.update_peers(new_peers)?;
         self.set_cidrs(new_cidrs);
-        self.write()?;
+        self.write_peers_and_cidrs()?;
 
         Ok(())
     }
 
     fn update_peers(&mut self, new_peers: &[Peer]) -> Result<(), Error> {
-        let peers = match &mut self.contents {
-            Contents::V1 { ref mut peers, .. } => peers,
+        let peers = match &mut self.peers_and_cidrs.contents {
+            PeersAndCidrs::V1 { ref mut peers, .. } => peers,
         };
 
         for new_peer in new_peers.iter() {
@@ -141,15 +194,30 @@ impl DataStore {
     }
 
     pub fn peers(&self) -> &[Peer] {
-        match &self.contents {
-            Contents::V1 { peers, .. } => peers,
+        match &self.peers_and_cidrs.contents {
+            PeersAndCidrs::V1 { peers, .. } => peers,
         }
     }
 
     pub fn cidrs(&self) -> &[Cidr] {
-        match &self.contents {
-            Contents::V1 { cidrs, .. } => cidrs,
+        match &self.peers_and_cidrs.contents {
+            PeersAndCidrs::V1 { cidrs, .. } => cidrs,
         }
+    }
+
+    fn set_cidrs(&mut self, new_cidrs: Vec<Cidr>) {
+        match &mut self.peers_and_cidrs.contents {
+            PeersAndCidrs::V1 { ref mut cidrs, .. } => *cidrs = new_cidrs,
+        }
+    }
+
+    fn write_peers_and_cidrs(&mut self) -> Result<(), io::Error> {
+        self.peers_and_cidrs.file.rewind()?;
+        self.peers_and_cidrs.file.set_len(0)?;
+        self.peers_and_cidrs
+            .file
+            .write_all(serde_json::to_string_pretty(&self.peers_and_cidrs.contents)?.as_bytes())?;
+        Ok(())
     }
 
     pub fn peer_endpoint_overrides(&self) -> &BTreeMap<IpAddr, Endpoint> {
@@ -170,8 +238,8 @@ impl DataStore {
     }
 
     fn inner_peer_endpoint_overrides(&self) -> &BTreeMap<IpAddr, Endpoint> {
-        match &self.contents {
-            Contents::V1 {
+        match &self.peer_endpoint_overrides.contents {
+            PeerEndpointOverrides::V1 {
                 peer_endpoint_overrides,
                 ..
             } => peer_endpoint_overrides,
@@ -179,26 +247,36 @@ impl DataStore {
     }
 
     fn inner_peer_endpoint_overrides_mut(&mut self) -> &mut BTreeMap<IpAddr, Endpoint> {
-        match &mut self.contents {
-            Contents::V1 {
+        match &mut self.peer_endpoint_overrides.contents {
+            PeerEndpointOverrides::V1 {
                 peer_endpoint_overrides,
                 ..
             } => peer_endpoint_overrides,
         }
     }
 
-    fn set_cidrs(&mut self, new_cidrs: Vec<Cidr>) {
-        match &mut self.contents {
-            Contents::V1 { ref mut cidrs, .. } => *cidrs = new_cidrs,
-        }
+    pub fn write_peer_endpoint_overrides(&mut self) -> Result<(), io::Error> {
+        self.peer_endpoint_overrides.file.rewind()?;
+        self.peer_endpoint_overrides.file.set_len(0)?;
+        self.peer_endpoint_overrides.file.write_all(
+            serde_json::to_string_pretty(&self.peer_endpoint_overrides.contents)?.as_bytes(),
+        )?;
+        Ok(())
     }
 
-    pub fn write(&mut self) -> Result<(), io::Error> {
-        self.file.rewind()?;
-        self.file.set_len(0)?;
-        self.file
-            .write_all(serde_json::to_string_pretty(&self.contents)?.as_bytes())?;
-        Ok(())
+    pub fn remove_files(data_dir: &Path, interface: &InterfaceName) {
+        let peers_and_cidrs = Self::get_peers_and_cidrs_path(data_dir, interface);
+        let peer_endpoint_overrides = Self::get_peer_endpoint_overrides_path(data_dir, interface);
+
+        std::fs::remove_file(&peers_and_cidrs)
+            .with_path(&peers_and_cidrs)
+            .map_err(|e| log::warn!("{}", e.to_string().yellow()))
+            .ok();
+
+        std::fs::remove_file(&peer_endpoint_overrides)
+            .with_path(&peer_endpoint_overrides)
+            .map_err(|e| log::warn!("{}", e.to_string().yellow()))
+            .ok();
     }
 }
 
@@ -237,7 +315,8 @@ mod tests {
     });
 
     fn setup_basic_store(dir: &Path) {
-        let mut store = DataStore::open_with_path(dir.join("peer_store.json"), true).unwrap();
+        let interface_name: InterfaceName = "peer_store".parse().unwrap();
+        let mut store = DataStore::open_or_create(dir, &interface_name).unwrap();
 
         println!("{store:?}");
         assert_eq!(0, store.peers().len());
@@ -252,7 +331,8 @@ mod tests {
     fn test_sanity() {
         let dir = tempfile::tempdir().unwrap();
         setup_basic_store(dir.path());
-        let store = DataStore::open_with_path(dir.path().join("peer_store.json"), false).unwrap();
+        let interface_name: InterfaceName = "peer_store".parse().unwrap();
+        let store = DataStore::open(dir.path(), &interface_name).unwrap();
         assert_eq!(store.peers(), &*BASE_PEERS);
         assert_eq!(store.cidrs(), &*BASE_CIDRS);
     }
@@ -261,8 +341,9 @@ mod tests {
     fn test_pinning() {
         let dir = tempfile::tempdir().unwrap();
         setup_basic_store(dir.path());
-        let mut store =
-            DataStore::open_with_path(dir.path().join("peer_store.json"), false).unwrap();
+
+        let interface_name: InterfaceName = "peer_store".parse().unwrap();
+        let mut store = DataStore::open(dir.path(), &interface_name).unwrap();
 
         // Should work, since peer is unmodified.
         store.update_peers(&BASE_PEERS).unwrap();
@@ -278,8 +359,9 @@ mod tests {
     fn test_peer_persistence() {
         let dir = tempfile::tempdir().unwrap();
         setup_basic_store(dir.path());
-        let mut store =
-            DataStore::open_with_path(dir.path().join("peer_store.json"), false).unwrap();
+
+        let interface_name: InterfaceName = "peer_store".parse().unwrap();
+        let mut store = DataStore::open(dir.path(), &interface_name).unwrap();
 
         // Should work, since peer is unmodified.
         store.update_peers(&[]).unwrap();

--- a/client-core/src/data_store.rs
+++ b/client-core/src/data_store.rs
@@ -160,12 +160,12 @@ impl DataStore {
         self.inner_peer_endpoint_overrides().get(&peer_ip).cloned()
     }
 
-    pub fn override_endpoint_for_peer(&mut self, peer_ip: IpAddr, endpoint: Endpoint) {
+    pub fn set_endpoint_override_for_peer(&mut self, peer_ip: IpAddr, endpoint: Endpoint) {
         self.inner_peer_endpoint_overrides_mut()
             .insert(peer_ip, endpoint);
     }
 
-    pub fn unset_endpoint_for_peer(&mut self, peer_ip: IpAddr) {
+    pub fn unset_endpoint_override_for_peer(&mut self, peer_ip: IpAddr) {
         self.inner_peer_endpoint_overrides_mut().remove(&peer_ip);
     }
 

--- a/client-core/src/data_store.rs
+++ b/client-core/src/data_store.rs
@@ -1,25 +1,30 @@
 use anyhow::{bail, Error};
-use colored::Colorize;
-use innernet_shared::{
-    chmod, ensure_dirs_exist, Cidr, Endpoint, IoErrorContext, Peer, WrappedIoError,
-};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use innernet_shared::{chmod, ensure_dirs_exist, Cidr, IoErrorContext, Peer, WrappedIoError};
+use serde::{Deserialize, Serialize};
 use std::{
-    collections::BTreeMap,
     fs::{File, OpenOptions},
     io::{self, Read, Seek, Write},
-    net::IpAddr,
     path::{Path, PathBuf},
 };
 use wireguard_control::InterfaceName;
 
+/// File-backed storage of [`Peer`]s and [`Cidr`]s.
+///
+/// The file is stored at [`Self::get_path()`].
 #[derive(Debug)]
-struct FileBackedData<T> {
+pub struct DataStore {
     file: File,
-    contents: T,
+    contents: Contents,
 }
 
-impl<T: Default + DeserializeOwned + Serialize> FileBackedData<T> {
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "version")]
+enum Contents {
+    #[serde(rename = "1")]
+    V1 { peers: Vec<Peer>, cidrs: Vec<Cidr> },
+}
+
+impl DataStore {
     fn open_with_path<P: AsRef<Path>>(path: P, create: bool) -> Result<Self, WrappedIoError> {
         let path = path.as_ref();
         let is_existing_file = path.exists();
@@ -39,82 +44,17 @@ impl<T: Default + DeserializeOwned + Serialize> FileBackedData<T> {
 
         let mut json = String::new();
         file.read_to_string(&mut json).with_path(path)?;
-        let contents = serde_json::from_str(&json).unwrap_or_else(|_| T::default());
+        let contents = serde_json::from_str(&json).unwrap_or_else(|_| Contents::V1 {
+            peers: vec![],
+            cidrs: vec![],
+        });
 
         Ok(Self { file, contents })
     }
 
-    fn write(&mut self) -> Result<(), io::Error> {
-        self.file.rewind()?;
-        self.file.set_len(0)?;
-        self.file
-            .write_all(serde_json::to_string_pretty(&self.contents)?.as_bytes())?;
-        Ok(())
-    }
-}
-
-#[derive(Debug)]
-pub struct DataStore {
-    /// File-backed storage of [`Peer`]s and [`Cidr`]s.
-    ///
-    /// The file is stored at [`Self::get_peers_and_cidrs_path()`].
-    peers_and_cidrs: FileBackedData<PeersAndCidrs>,
-
-    /// File-backed storage of [`PeerEndpointOverrides`]s.
-    ///
-    /// The file is stored at [`Self::get_peer_endpoint_overrides_path()`].
-    peer_endpoint_overrides: FileBackedData<PeerEndpointOverrides>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(tag = "version")]
-enum PeersAndCidrs {
-    #[serde(rename = "1")]
-    V1 { peers: Vec<Peer>, cidrs: Vec<Cidr> },
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(tag = "version")]
-enum PeerEndpointOverrides {
-    #[serde(rename = "1")]
-    V1 {
-        /// This field was added in innernet 1.8, but the change is
-        /// backwards-compatible, we thus kept it in v1
-        #[serde(default)]
-        peer_endpoint_overrides: BTreeMap<IpAddr, Endpoint>,
-    },
-}
-
-impl Default for PeersAndCidrs {
-    fn default() -> Self {
-        Self::V1 {
-            peers: vec![],
-            cidrs: vec![],
-        }
-    }
-}
-
-impl Default for PeerEndpointOverrides {
-    fn default() -> Self {
-        Self::V1 {
-            peer_endpoint_overrides: BTreeMap::new(),
-        }
-    }
-}
-
-impl DataStore {
     /// Produce the path "`data_dir`/`interface`.json".
-    pub fn get_peers_and_cidrs_path(data_dir: &Path, interface: &InterfaceName) -> PathBuf {
+    pub fn get_path(data_dir: &Path, interface: &InterfaceName) -> PathBuf {
         data_dir.join(interface.to_string()).with_extension("json")
-    }
-
-    /// Produce the path "`data_dir`/`interface`.peer-endpoint-overrides.json".
-    pub fn get_peer_endpoint_overrides_path(data_dir: &Path, interface: &InterfaceName) -> PathBuf {
-        let file_name = format!("{interface}.peer-endpoint-overrides.json");
-
-        // Warning - if you use `.with_extension("json")` here instead of inlining it above,
-        //           it will result in `{interface}.json` which is undesirable.
-        data_dir.join(file_name)
     }
 
     fn _open(
@@ -123,30 +63,15 @@ impl DataStore {
         create: bool,
     ) -> Result<Self, WrappedIoError> {
         ensure_dirs_exist(&[data_dir])?;
-
-        let peers_and_cidrs = FileBackedData::open_with_path(
-            Self::get_peers_and_cidrs_path(data_dir, interface),
-            create,
-        )?;
-
-        let peer_endpoint_overrides = FileBackedData::open_with_path(
-            Self::get_peer_endpoint_overrides_path(data_dir, interface),
-            // Always create the peer overrides file if it doesn't exist.
-            true,
-        )?;
-
-        Ok(Self {
-            peers_and_cidrs,
-            peer_endpoint_overrides,
-        })
+        Self::open_with_path(Self::get_path(data_dir, interface), create)
     }
 
-    /// Open the data store residing in the "`data_dir`" directory.
+    /// Open the data store residing at "`data_dir`/`interface`.json".
     pub fn open(data_dir: &Path, interface: &InterfaceName) -> Result<Self, WrappedIoError> {
         Self::_open(data_dir, interface, false)
     }
 
-    /// Open or create the data store residing in the "`data_dir`" directory.
+    /// Open or create the data store residing at "`data_dir`/`interface`.json".
     pub fn open_or_create(
         data_dir: &Path,
         interface: &InterfaceName,
@@ -169,14 +94,14 @@ impl DataStore {
     ) -> Result<(), Error> {
         self.update_peers(new_peers)?;
         self.set_cidrs(new_cidrs);
-        self.write_peers_and_cidrs()?;
+        self.write()?;
 
         Ok(())
     }
 
     fn update_peers(&mut self, new_peers: &[Peer]) -> Result<(), Error> {
-        let peers = match &mut self.peers_and_cidrs.contents {
-            PeersAndCidrs::V1 { ref mut peers, .. } => peers,
+        let peers = match &mut self.contents {
+            Contents::V1 { ref mut peers, .. } => peers,
         };
 
         for new_peer in new_peers.iter() {
@@ -204,81 +129,29 @@ impl DataStore {
     }
 
     pub fn peers(&self) -> &[Peer] {
-        match &self.peers_and_cidrs.contents {
-            PeersAndCidrs::V1 { peers, .. } => peers,
+        match &self.contents {
+            Contents::V1 { peers, .. } => peers,
         }
     }
 
     pub fn cidrs(&self) -> &[Cidr] {
-        match &self.peers_and_cidrs.contents {
-            PeersAndCidrs::V1 { cidrs, .. } => cidrs,
+        match &self.contents {
+            Contents::V1 { cidrs, .. } => cidrs,
         }
     }
 
     fn set_cidrs(&mut self, new_cidrs: Vec<Cidr>) {
-        match &mut self.peers_and_cidrs.contents {
-            PeersAndCidrs::V1 { ref mut cidrs, .. } => *cidrs = new_cidrs,
+        match &mut self.contents {
+            Contents::V1 { ref mut cidrs, .. } => *cidrs = new_cidrs,
         }
     }
 
-    fn write_peers_and_cidrs(&mut self) -> Result<(), io::Error> {
-        self.peers_and_cidrs.write()?;
+    fn write(&mut self) -> Result<(), io::Error> {
+        self.file.rewind()?;
+        self.file.set_len(0)?;
+        self.file
+            .write_all(serde_json::to_string_pretty(&self.contents)?.as_bytes())?;
         Ok(())
-    }
-
-    pub fn peer_endpoint_overrides(&self) -> &BTreeMap<IpAddr, Endpoint> {
-        self.inner_peer_endpoint_overrides()
-    }
-
-    pub fn endpoint_override_for_peer(&self, peer_ip: IpAddr) -> Option<Endpoint> {
-        self.inner_peer_endpoint_overrides().get(&peer_ip).cloned()
-    }
-
-    pub fn set_endpoint_override_for_peer(&mut self, peer_ip: IpAddr, endpoint: Endpoint) {
-        self.inner_peer_endpoint_overrides_mut()
-            .insert(peer_ip, endpoint);
-    }
-
-    pub fn unset_endpoint_override_for_peer(&mut self, peer_ip: IpAddr) {
-        self.inner_peer_endpoint_overrides_mut().remove(&peer_ip);
-    }
-
-    fn inner_peer_endpoint_overrides(&self) -> &BTreeMap<IpAddr, Endpoint> {
-        match &self.peer_endpoint_overrides.contents {
-            PeerEndpointOverrides::V1 {
-                peer_endpoint_overrides,
-                ..
-            } => peer_endpoint_overrides,
-        }
-    }
-
-    fn inner_peer_endpoint_overrides_mut(&mut self) -> &mut BTreeMap<IpAddr, Endpoint> {
-        match &mut self.peer_endpoint_overrides.contents {
-            PeerEndpointOverrides::V1 {
-                peer_endpoint_overrides,
-                ..
-            } => peer_endpoint_overrides,
-        }
-    }
-
-    pub fn write_peer_endpoint_overrides(&mut self) -> Result<(), io::Error> {
-        self.peer_endpoint_overrides.write()?;
-        Ok(())
-    }
-
-    pub fn remove_files(data_dir: &Path, interface: &InterfaceName) {
-        let peers_and_cidrs = Self::get_peers_and_cidrs_path(data_dir, interface);
-        let peer_endpoint_overrides = Self::get_peer_endpoint_overrides_path(data_dir, interface);
-
-        std::fs::remove_file(&peers_and_cidrs)
-            .with_path(&peers_and_cidrs)
-            .map_err(|e| log::warn!("{}", e.to_string().yellow()))
-            .ok();
-
-        std::fs::remove_file(&peer_endpoint_overrides)
-            .with_path(&peer_endpoint_overrides)
-            .map_err(|e| log::warn!("{}", e.to_string().yellow()))
-            .ok();
     }
 }
 
@@ -317,8 +190,7 @@ mod tests {
     });
 
     fn setup_basic_store(dir: &Path) {
-        let interface_name: InterfaceName = "peer_store".parse().unwrap();
-        let mut store = DataStore::open_or_create(dir, &interface_name).unwrap();
+        let mut store = DataStore::open_with_path(dir.join("peer_store.json"), true).unwrap();
 
         println!("{store:?}");
         assert_eq!(0, store.peers().len());
@@ -333,8 +205,7 @@ mod tests {
     fn test_sanity() {
         let dir = tempfile::tempdir().unwrap();
         setup_basic_store(dir.path());
-        let interface_name: InterfaceName = "peer_store".parse().unwrap();
-        let store = DataStore::open(dir.path(), &interface_name).unwrap();
+        let store = DataStore::open_with_path(dir.path().join("peer_store.json"), false).unwrap();
         assert_eq!(store.peers(), &*BASE_PEERS);
         assert_eq!(store.cidrs(), &*BASE_CIDRS);
     }
@@ -343,9 +214,8 @@ mod tests {
     fn test_pinning() {
         let dir = tempfile::tempdir().unwrap();
         setup_basic_store(dir.path());
-
-        let interface_name: InterfaceName = "peer_store".parse().unwrap();
-        let mut store = DataStore::open(dir.path(), &interface_name).unwrap();
+        let mut store =
+            DataStore::open_with_path(dir.path().join("peer_store.json"), false).unwrap();
 
         // Should work, since peer is unmodified.
         store.update_peers(&BASE_PEERS).unwrap();
@@ -361,9 +231,8 @@ mod tests {
     fn test_peer_persistence() {
         let dir = tempfile::tempdir().unwrap();
         setup_basic_store(dir.path());
-
-        let interface_name: InterfaceName = "peer_store".parse().unwrap();
-        let mut store = DataStore::open(dir.path(), &interface_name).unwrap();
+        let mut store =
+            DataStore::open_with_path(dir.path().join("peer_store.json"), false).unwrap();
 
         // Should work, since peer is unmodified.
         store.update_peers(&[]).unwrap();

--- a/client-core/src/data_store.rs
+++ b/client-core/src/data_store.rs
@@ -150,14 +150,12 @@ impl DataStore {
         }
     }
 
-    pub fn local_endpoint_overrides(&self) -> impl Iterator<Item = (IpAddr, Endpoint)> + '_ {
+    pub fn local_endpoint_overrides(&self) -> &HashMap<IpAddr, Endpoint> {
         match &self.contents {
             Contents::V1 {
                 local_endpoint_overrides,
                 ..
-            } => local_endpoint_overrides
-                .iter()
-                .map(|(ip, socket)| (*ip, socket.clone())),
+            } => local_endpoint_overrides,
         }
     }
 

--- a/client-core/src/data_store.rs
+++ b/client-core/src/data_store.rs
@@ -4,7 +4,7 @@ use innernet_shared::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
     fs::{File, OpenOptions},
     io::{self, Read, Seek, Write},
     net::IpAddr,
@@ -28,8 +28,10 @@ enum Contents {
     V1 {
         peers: Vec<Peer>,
         cidrs: Vec<Cidr>,
+
+        /// This field was added in innernet 1.8, but the change is backwards-compatible, we thus kept it in v1
         #[serde(default)]
-        local_endpoint_overrides: HashMap<IpAddr, Endpoint>,
+        peer_endpoint_overrides: BTreeMap<IpAddr, Endpoint>,
     },
 }
 
@@ -56,7 +58,7 @@ impl DataStore {
         let contents = serde_json::from_str(&json).unwrap_or_else(|_| Contents::V1 {
             peers: vec![],
             cidrs: vec![],
-            local_endpoint_overrides: HashMap::new(),
+            peer_endpoint_overrides: BTreeMap::new(),
         });
 
         Ok(Self { file, contents })
@@ -150,43 +152,38 @@ impl DataStore {
         }
     }
 
-    pub fn local_endpoint_overrides(&self) -> &HashMap<IpAddr, Endpoint> {
-        match &self.contents {
-            Contents::V1 {
-                local_endpoint_overrides,
-                ..
-            } => local_endpoint_overrides,
-        }
+    pub fn peer_endpoint_overrides(&self) -> &BTreeMap<IpAddr, Endpoint> {
+        self.inner_peer_endpoint_overrides()
     }
 
     pub fn endpoint_override_for_peer(&self, peer_ip: IpAddr) -> Option<Endpoint> {
-        match &self.contents {
-            Contents::V1 {
-                local_endpoint_overrides,
-                ..
-            } => local_endpoint_overrides.get(&peer_ip).cloned(),
-        }
+        self.inner_peer_endpoint_overrides().get(&peer_ip).cloned()
     }
 
     pub fn override_endpoint_for_peer(&mut self, peer_ip: IpAddr, endpoint: Endpoint) {
-        match &mut self.contents {
-            Contents::V1 {
-                local_endpoint_overrides,
-                ..
-            } => {
-                local_endpoint_overrides.insert(peer_ip, endpoint);
-            },
-        }
+        self.inner_peer_endpoint_overrides_mut()
+            .insert(peer_ip, endpoint);
     }
 
     pub fn unset_endpoint_for_peer(&mut self, peer_ip: IpAddr) {
+        self.inner_peer_endpoint_overrides_mut().remove(&peer_ip);
+    }
+
+    fn inner_peer_endpoint_overrides(&self) -> &BTreeMap<IpAddr, Endpoint> {
+        match &self.contents {
+            Contents::V1 {
+                peer_endpoint_overrides,
+                ..
+            } => peer_endpoint_overrides,
+        }
+    }
+
+    fn inner_peer_endpoint_overrides_mut(&mut self) -> &mut BTreeMap<IpAddr, Endpoint> {
         match &mut self.contents {
             Contents::V1 {
-                local_endpoint_overrides,
+                peer_endpoint_overrides,
                 ..
-            } => {
-                local_endpoint_overrides.remove(&peer_ip);
-            },
+            } => peer_endpoint_overrides,
         }
     }
 

--- a/client-core/src/interface.rs
+++ b/client-core/src/interface.rs
@@ -242,8 +242,8 @@ pub fn fetch(
             endpoint_override
         );
 
-        if let Some(peer) = peers.iter_mut().find(|p| p.ip == peer_ip) {
-            peer.endpoint = Some(endpoint_override);
+        if let Some(peer) = peers.iter_mut().find(|p| p.ip == *peer_ip) {
+            peer.endpoint = Some(endpoint_override.clone());
         }
     }
 

--- a/client-core/src/interface.rs
+++ b/client-core/src/interface.rs
@@ -235,7 +235,7 @@ pub fn fetch(
     };
 
     // Apply the local peer endpoint overrides.
-    for (peer_ip, endpoint_override) in store.local_endpoint_overrides() {
+    for (peer_ip, endpoint_override) in store.peer_endpoint_overrides() {
         log::debug!(
             "overriding peer IP {} with endpoint {}",
             peer_ip,

--- a/client-core/src/interface.rs
+++ b/client-core/src/interface.rs
@@ -235,7 +235,7 @@ pub fn fetch(
     };
 
     // Apply the local peer endpoint overrides.
-    for (peer_ip, endpoint_override) in store.peer_endpoint_overrides() {
+    for (peer_ip, endpoint_override) in config.peer_endpoint_overrides() {
         log::debug!(
             "overriding peer IP {} with endpoint {}",
             peer_ip,

--- a/client-core/src/interface.rs
+++ b/client-core/src/interface.rs
@@ -286,7 +286,8 @@ pub fn fetch(
     if nat.no_nat_traversal {
         log::debug!("NAT traversal explicitly disabled, not attempting.");
     } else {
-        let mut nat_traverse = NatTraverse::new(interface, network_opts.backend, &modifications)?;
+        let mut nat_traverse =
+            NatTraverse::new(interface, &config, network_opts.backend, &modifications)?;
 
         // Give time for handshakes with recently changed endpoints to complete before attempting traversal.
         if !nat_traverse.is_finished() {

--- a/client-core/src/interface.rs
+++ b/client-core/src/interface.rs
@@ -243,7 +243,7 @@ pub fn fetch(
         );
 
         if let Some(peer) = peers.iter_mut().find(|p| p.ip == peer_ip) {
-            peer.endpoint = Some(endpoint_override.into());
+            peer.endpoint = Some(endpoint_override);
         }
     }
 

--- a/client-core/src/interface.rs
+++ b/client-core/src/interface.rs
@@ -16,7 +16,7 @@ use innernet_shared::{
 };
 use std::{io, net::SocketAddr, path::Path, thread, time::Instant};
 use thiserror::Error;
-use wireguard_control::{Device, DeviceUpdate, PeerConfigBuilder};
+use wireguard_control::{Backend, Device, DeviceUpdate, PeerConfigBuilder};
 
 #[derive(Debug, Error)]
 pub enum RedeemInviteError {
@@ -163,10 +163,7 @@ pub fn fetch(
     bring_up_interface: bool,
 ) -> Result<(), Error> {
     let config = InterfaceConfig::from_interface(config_dir, interface)?;
-    let interface_up = match Device::list(network_opts.backend) {
-        Ok(interfaces) => interfaces.iter().any(|name| name == interface),
-        _ => false,
-    };
+    let interface_up = interface_is_up(network_opts.backend, interface);
 
     if !interface_up {
         if !bring_up_interface {
@@ -400,4 +397,11 @@ fn report_candidates(
 
     log::debug!("candidates successfully reported");
     Ok(())
+}
+
+pub fn interface_is_up(backend: Backend, interface_name: &InterfaceName) -> bool {
+    match Device::list(backend) {
+        Ok(interfaces) => interfaces.contains(interface_name),
+        _ => false,
+    }
 }

--- a/client-core/src/interface.rs
+++ b/client-core/src/interface.rs
@@ -206,7 +206,8 @@ pub fn fetch(
     );
     let mut store = DataStore::open_or_create(data_dir, interface)?;
     let rest_client = RestClient::new(&config.server);
-    let (State { peers, cidrs }, server_is_reachable) = match rest_client.http("GET", "/user/state")
+    let (State { mut peers, cidrs }, server_is_reachable) = match rest_client
+        .http("GET", "/user/state")
     {
         Ok(state) => (state, true),
         Err(e) => {
@@ -232,6 +233,19 @@ pub fn fetch(
             }
         },
     };
+
+    // Apply the local peer endpoint overrides.
+    for (peer_ip, endpoint_override) in store.local_endpoint_overrides() {
+        log::debug!(
+            "overriding peer IP {} with endpoint {}",
+            peer_ip,
+            endpoint_override
+        );
+
+        if let Some(peer) = peers.iter_mut().find(|p| p.ip == peer_ip) {
+            peer.endpoint = Some(endpoint_override.into());
+        }
+    }
 
     let device = Device::get(interface, network_opts.backend)?;
     let modifications = device.diff(&peers);

--- a/client-core/src/lib.rs
+++ b/client-core/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! This is a work in progress but the final goal is to match the `innernet` CLI API surface.
 
+use crate::interface::interface_is_up;
 pub use innernet_shared::{
     interface_config::PeerInvitation, Cidr, CidrTree, Endpoint, HostsOpts, NatOpts, NetworkOpts,
     Peer, WrappedIoError, DEFAULT_HOSTS_PATH,
@@ -55,12 +56,14 @@ pub fn set_endpoint_override_for_peer(
     config.set_endpoint_override_for_peer(peer.ip, endpoint.clone());
     config.save(config_dir, interface)?;
 
-    let socket_addr = endpoint.resolve()?;
-    let peer_pub_key = Key::from_base64(&peer.public_key).unwrap();
+    if interface_is_up(network_backend, interface) {
+        let socket_addr = endpoint.resolve()?;
+        let peer_pub_key = Key::from_base64(&peer.public_key).unwrap();
 
-    DeviceUpdate::new()
-        .add_peer(PeerConfigBuilder::new(&peer_pub_key).set_endpoint(socket_addr))
-        .apply(interface, network_backend)?;
+        DeviceUpdate::new()
+            .add_peer(PeerConfigBuilder::new(&peer_pub_key).set_endpoint(socket_addr))
+            .apply(interface, network_backend)?;
+    }
 
     Ok(())
 }

--- a/client-core/src/lib.rs
+++ b/client-core/src/lib.rs
@@ -7,6 +7,7 @@ pub use innernet_shared::{
     Peer, WrappedIoError, DEFAULT_HOSTS_PATH,
 };
 pub use wireguard_control::Backend;
+use wireguard_control::{DeviceUpdate, Key, PeerConfigBuilder};
 
 use anyhow::Error;
 use innernet_shared::wg;
@@ -39,6 +40,39 @@ pub fn set_listen_port(
     config.interface.listen_port = listen_port;
     config.save(config_dir, interface)?;
     log::info!("the config file is updated");
+
+    Ok(())
+}
+
+pub fn set_endpoint_override_for_peer(
+    network_backend: Backend,
+    config_dir: &Path,
+    interface: &interface::InterfaceName,
+    config: &mut interface::InterfaceConfig,
+    peer: &Peer,
+    endpoint: Endpoint,
+) -> Result<(), Error> {
+    config.set_endpoint_override_for_peer(peer.ip, endpoint.clone());
+    config.save(config_dir, interface)?;
+
+    let socket_addr = endpoint.resolve()?;
+    let peer_pub_key = Key::from_base64(&peer.public_key).unwrap();
+
+    DeviceUpdate::new()
+        .add_peer(PeerConfigBuilder::new(&peer_pub_key).set_endpoint(socket_addr))
+        .apply(interface, network_backend)?;
+
+    Ok(())
+}
+
+pub fn unset_endpoint_override_for_peer(
+    config_dir: &Path,
+    interface: &interface::InterfaceName,
+    config: &mut interface::InterfaceConfig,
+    peer: &Peer,
+) -> Result<(), Error> {
+    config.unset_endpoint_override_for_peer(peer.ip);
+    config.save(config_dir, interface)?;
 
     Ok(())
 }

--- a/client-core/src/nat.rs
+++ b/client-core/src/nat.rs
@@ -3,6 +3,7 @@
 //! Doesn't follow the specific ICE protocol, but takes great inspiration from RFC 8445
 //! and applies it to a protocol more specific to innernet.
 
+use innernet_shared::interface_config::InterfaceConfig;
 use std::time::{Duration, Instant};
 
 use anyhow::Error;
@@ -23,11 +24,18 @@ pub struct NatTraverse<'a> {
 impl<'a> NatTraverse<'a> {
     pub fn new(
         interface: &'a InterfaceName,
+        interface_config: &InterfaceConfig,
         backend: Backend,
         diffs: &[PeerDiff],
     ) -> Result<Self, Error> {
         // Filter out removed peers from diffs list.
-        let mut remaining: Vec<_> = diffs.iter().filter_map(|diff| diff.new).cloned().collect();
+        let mut remaining: Vec<_> = diffs
+            .iter()
+            .filter_map(|diff| diff.new)
+            // Don't attempt NAT traversal for peers with an overridden endpoint.
+            .filter(|peer| !interface_config.peer_endpoint_overrides().contains_key(&peer.ip))
+            .cloned()
+            .collect();
 
         for peer in &mut remaining {
             // Limit reported alternative candidates to 10.

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -534,7 +534,7 @@ fn list_cidrs(interface: &InterfaceName, opts: &Opts, tree: bool) -> Result<(), 
     if tree {
         let cidr_tree = CidrTree::new(data_store.cidrs());
         colored::control::set_override(false);
-        print_tree(&cidr_tree, &[], 0, false);
+        print_tree(&cidr_tree, &[], 0, false, &data_store);
         colored::control::unset_override();
     } else {
         for cidr in data_store.cidrs() {
@@ -911,17 +911,23 @@ fn show(opts: &Opts, short: bool, tree: bool, interface: Option<Interface>) -> R
 
         if tree {
             let cidr_tree = CidrTree::new(cidrs);
-            print_tree(&cidr_tree, &peer_states, 1, verbose);
+            print_tree(&cidr_tree, &peer_states, 1, verbose, &store);
         } else {
             for peer_state in peer_states {
-                print_peer(&peer_state, short, 1, verbose);
+                print_peer(&peer_state, short, 1, verbose, &store);
             }
         }
     }
     Ok(())
 }
 
-fn print_tree(cidr: &CidrTree, peers: &[PeerState], level: usize, verbose: bool) {
+fn print_tree(
+    cidr: &CidrTree,
+    peers: &[PeerState],
+    level: usize,
+    verbose: bool,
+    data_store: &DataStore,
+) {
     println_pad!(
         level * 2,
         "{} {}",
@@ -933,10 +939,10 @@ fn print_tree(cidr: &CidrTree, peers: &[PeerState], level: usize, verbose: bool)
     children.sort();
     children
         .iter()
-        .for_each(|child| print_tree(child, peers, level + 1, verbose));
+        .for_each(|child| print_tree(child, peers, level + 1, verbose, data_store));
 
     for peer in peers.iter().filter(|p| p.peer.cidr_id == cidr.id) {
-        print_peer(peer, true, level, verbose);
+        print_peer(peer, true, level, verbose, data_store);
     }
 }
 
@@ -964,7 +970,7 @@ fn print_interface(device_info: &Device, short: bool) -> Result<(), Error> {
     Ok(())
 }
 
-fn print_peer(peer: &PeerState, short: bool, level: usize, verbose: bool) {
+fn print_peer(peer: &PeerState, short: bool, level: usize, verbose: bool, data_store: &DataStore) {
     let pad = level * 2;
     let PeerState { peer, info } = peer;
     let public_key = if verbose {
@@ -972,16 +978,23 @@ fn print_peer(peer: &PeerState, short: bool, level: usize, verbose: bool) {
     } else {
         &format!("{}…", &peer.public_key[..10])
     };
+
+    let endpoint_has_local_override = data_store.endpoint_override_for_peer(peer.ip).is_some();
+    let endpoint_override_msg = if endpoint_has_local_override {
+        " (local endpoint override)"
+    } else {
+        ""
+    };
+
     if short {
         let connected = info
             .map(|info| info.is_recently_connected())
             .unwrap_or_default();
-
         let is_you = info.is_none();
 
         println_pad!(
             pad,
-            "| {} {}: {} ({}{})",
+            "| {} {}: {} ({}{}){}",
             if connected || is_you {
                 "◉".bold()
             } else {
@@ -991,6 +1004,7 @@ fn print_peer(peer: &PeerState, short: bool, level: usize, verbose: bool) {
             peer.name.yellow(),
             if is_you { "you, " } else { "" },
             public_key.dimmed(),
+            endpoint_override_msg,
         );
     } else {
         println_pad!(
@@ -1003,7 +1017,13 @@ fn print_peer(peer: &PeerState, short: bool, level: usize, verbose: bool) {
         println_pad!(pad, "  {}: {}", "ip".bold(), peer.ip);
         if let Some(info) = info {
             if let Some(endpoint) = info.config.endpoint {
-                println_pad!(pad, "  {}: {}", "endpoint".bold(), endpoint);
+                println_pad!(
+                    pad,
+                    "  {}: {}{}",
+                    "endpoint".bold(),
+                    endpoint,
+                    endpoint_override_msg
+                );
             }
             if let Some(last_handshake) = info.stats.last_handshake_time {
                 let duration = last_handshake.elapsed().expect("horrible clock problem");

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -16,7 +16,8 @@ use innernet_shared::{
     AddDeleteAssociationOpts, AddPeerOpts, Association, AssociationContents, Cidr, CidrTree,
     DeleteCidrOpts, EnableDisablePeerOpts, Endpoint, EndpointContents, Error, HostsOpts,
     InstallOpts, Interface, IoErrorContext, ListenPortOpts, NatOpts, NetworkOpts,
-    OverrideEndpointOpts, Peer, RenameCidrOpts, RenamePeerOpts, ServerCapabilities, WrappedIoError,
+    OverrideEndpointOpts, OverridePeerEndpointOpts, Peer, RenameCidrOpts, RenamePeerOpts,
+    ServerCapabilities, WrappedIoError,
 };
 use std::{
     io,
@@ -25,7 +26,7 @@ use std::{
     time::Duration,
 };
 use util::{human_duration, human_size};
-use wireguard_control::{Device, InterfaceName, PeerInfo};
+use wireguard_control::{Device, DeviceUpdate, InterfaceName, PeerConfigBuilder, PeerInfo};
 
 mod util;
 
@@ -250,6 +251,13 @@ enum Command {
 
         #[clap(flatten)]
         sub_opts: OverrideEndpointOpts,
+    },
+
+    OverridePeerEndpoint {
+        interface: Interface,
+
+        #[clap(flatten)]
+        sub_opts: OverridePeerEndpointOpts,
     },
 
     /// Generate shell completion scripts
@@ -781,6 +789,49 @@ fn override_endpoint(
     Ok(())
 }
 
+fn override_peer_endpoint(
+    interface: &InterfaceName,
+    opts: &Opts,
+    sub_opts: OverridePeerEndpointOpts,
+) -> Result<(), Error> {
+    let _config = InterfaceConfig::from_interface(&opts.config_dir, interface)?;
+
+    let mut data_store = DataStore::open(&opts.data_dir, interface)?;
+
+    if let Some((peer_ip, peer_pub_key, endpoint_opt)) =
+        prompts::override_peer_endpoint_prompt(data_store.peers(), &sub_opts)?
+    {
+        if let Some(endpoint) = endpoint_opt {
+            log::info!(
+                "overriding endpoint for peer IP {} with endpoint {}",
+                peer_ip,
+                endpoint
+            );
+            data_store.override_endpoint_for_peer(peer_ip, endpoint.clone());
+
+            let socket_addr = endpoint.resolve()?;
+
+            DeviceUpdate::new()
+                .add_peer(PeerConfigBuilder::new(&peer_pub_key).set_endpoint(socket_addr))
+                .apply(interface, opts.network.backend)?;
+        } else {
+            log::info!(
+                "unsetting endpoint override for peer IP {} with endpoint",
+                peer_ip
+            );
+            data_store.unset_endpoint_for_peer(peer_ip);
+        }
+
+        // TODO(bschwind) - Should we do NAT traversal too?
+
+        data_store.write()?;
+    } else {
+        log::info!("exiting without overriding peer endpoint");
+    }
+
+    Ok(())
+}
+
 fn prompt_override_endpoint(
     server_capabilities: &ServerCapabilities,
     args: &OverrideEndpointOpts,
@@ -1162,6 +1213,12 @@ fn run(opts: &Opts) -> Result<(), Error> {
             sub_opts,
         } => {
             override_endpoint(&interface, opts, sub_opts)?;
+        },
+        Command::OverridePeerEndpoint {
+            interface,
+            sub_opts,
+        } => {
+            override_peer_endpoint(&interface, opts, sub_opts)?;
         },
         Command::Completions { shell } => {
             use clap::CommandFactory;

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,5 +1,5 @@
 use crate::util::all_installed;
-use anyhow::{anyhow, bail};
+use anyhow::{anyhow, bail, Error};
 use clap::{ArgAction, Parser, Subcommand};
 use colored::*;
 use dialoguer::{Confirm, Input};
@@ -14,10 +14,10 @@ use innernet_client_core::{
 use innernet_shared::{
     interface_config::InterfaceConfig, prompts, wg, wg::PeerInfoExt, AddCidrOpts,
     AddDeleteAssociationOpts, AddPeerOpts, Association, AssociationContents, Cidr, CidrTree,
-    DeleteCidrOpts, EnableDisablePeerOpts, Endpoint, EndpointContents, Error, HostsOpts,
-    InstallOpts, Interface, IoErrorContext, ListenPortOpts, NatOpts, NetworkOpts,
-    OverrideEndpointOpts, OverridePeerEndpointOpts, Peer, RenameCidrOpts, RenamePeerOpts,
-    ServerCapabilities, WrappedIoError,
+    DeleteCidrOpts, EnableDisablePeerOpts, Endpoint, EndpointContents, HostsOpts, InstallOpts,
+    Interface, IoErrorContext, ListenPortOpts, NatOpts, NetworkOpts, OverrideEndpointOpts,
+    OverridePeerEndpointOpts, Peer, RenameCidrOpts, RenamePeerOpts, ServerCapabilities,
+    WrappedIoError,
 };
 use std::{
     io,
@@ -540,14 +540,12 @@ fn delete_cidr(
 
 fn list_cidrs(interface: &InterfaceName, opts: &Opts, tree: bool) -> Result<(), Error> {
     let data_store = DataStore::open(&opts.data_dir, interface)?;
-
-    // TODO(bschwind) - Get this from InterfaceConfig.
-    let endpoint_has_local_override = false;
+    let config = InterfaceConfig::from_interface(&opts.config_dir, interface)?;
 
     if tree {
         let cidr_tree = CidrTree::new(data_store.cidrs());
         colored::control::set_override(false);
-        print_tree(&cidr_tree, &[], 0, false, endpoint_has_local_override);
+        print_tree(&cidr_tree, &[], 0, false, &config);
         colored::control::unset_override();
     } else {
         for cidr in data_store.cidrs() {
@@ -905,18 +903,24 @@ fn show(opts: &Opts, short: bool, tree: bool, interface: Option<Interface>) -> R
 
     let devices = interfaces
         .into_iter()
-        .filter_map(|name| {
-            match DataStore::open(&opts.data_dir, &name) {
-                Ok(store) => {
-                    let device =
-                        Device::get(&name, opts.network.backend).with_str(name.as_str_lossy());
-                    Some(device.map(|device| (device, store)))
-                },
+        .filter_map(|name| -> Option<Result<_, Error>> {
+            let data_store = match DataStore::open(&opts.data_dir, &name) {
+                Ok(store) => store,
                 // Skip WireGuard interfaces that aren't managed by innernet.
-                Err(e) if e.kind() == io::ErrorKind::NotFound => None,
+                Err(e) if e.kind() == io::ErrorKind::NotFound => return None,
                 // Error on interfaces that *are* managed by innernet but are not readable.
-                Err(e) => Some(Err(e)),
-            }
+                Err(e) => return Some(Err(e.into())),
+            };
+
+            let fallible_things = || {
+                let device =
+                    Device::get(&name, opts.network.backend).with_str(name.as_str_lossy())?;
+                let config = InterfaceConfig::from_interface(&opts.config_dir, &name)?;
+
+                Ok((device, data_store, config))
+            };
+
+            Some(fallible_things())
         })
         .collect::<Result<Vec<_>, _>>()?;
 
@@ -925,7 +929,7 @@ fn show(opts: &Opts, short: bool, tree: bool, interface: Option<Interface>) -> R
         return Ok(());
     }
 
-    for (device_info, store) in devices {
+    for (device_info, store, interface_config) in devices {
         let public_key = match &device_info.public_key {
             Some(key) => key.to_base64(),
             None => {
@@ -967,20 +971,14 @@ fn show(opts: &Opts, short: bool, tree: bool, interface: Option<Interface>) -> R
         peer_states.sort_by_key(|peer| peer.peer.ip);
         let verbose = opts.verbose > 0;
 
-        // TODO(bschwind) - Get this from InterfaceConfig.
-        let endpoint_has_local_override = false;
-
         if tree {
             let cidr_tree = CidrTree::new(cidrs);
-            print_tree(
-                &cidr_tree,
-                &peer_states,
-                1,
-                verbose,
-                endpoint_has_local_override,
-            );
+            print_tree(&cidr_tree, &peer_states, 1, verbose, &interface_config);
         } else {
             for peer_state in peer_states {
+                let endpoint_has_local_override = interface_config
+                    .peer_endpoint_overrides()
+                    .contains_key(&peer_state.peer.contents.ip);
                 print_peer(&peer_state, short, 1, verbose, endpoint_has_local_override);
             }
         }
@@ -993,7 +991,7 @@ fn print_tree(
     peers: &[PeerState],
     level: usize,
     verbose: bool,
-    endpoint_has_local_override: bool,
+    interface_config: &InterfaceConfig,
 ) {
     println_pad!(
         level * 2,
@@ -1004,17 +1002,14 @@ fn print_tree(
 
     let mut children: Vec<_> = cidr.children().collect();
     children.sort();
-    children.iter().for_each(|child| {
-        print_tree(
-            child,
-            peers,
-            level + 1,
-            verbose,
-            endpoint_has_local_override,
-        )
-    });
+    children
+        .iter()
+        .for_each(|child| print_tree(child, peers, level + 1, verbose, interface_config));
 
     for peer in peers.iter().filter(|p| p.peer.cidr_id == cidr.id) {
+        let endpoint_has_local_override = interface_config
+            .peer_endpoint_overrides()
+            .contains_key(&peer.peer.contents.ip);
         print_peer(peer, true, level, verbose, endpoint_has_local_override);
     }
 }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -808,7 +808,7 @@ fn override_peer_endpoint(
                 peer.ip,
                 endpoint
             );
-            data_store.override_endpoint_for_peer(peer.ip, endpoint.clone());
+            data_store.set_endpoint_override_for_peer(peer.ip, endpoint.clone());
 
             let socket_addr = endpoint.resolve()?;
             let peer_pub_key = Key::from_base64(&peer.public_key).unwrap();

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -908,25 +908,23 @@ fn show(opts: &Opts, short: bool, tree: bool, interface: Option<Interface>) -> R
 
     let devices = interfaces
         .into_iter()
-        .filter_map(|name| -> Option<Result<_, Error>> {
-            let data_store = match DataStore::open(&opts.data_dir, &name) {
-                Ok(store) => store,
+        .map(|name| -> Result<Option<_>, Error> {
+            match DataStore::open(&opts.data_dir, &name) {
+                Ok(store) => {
+                    let device =
+                        Device::get(&name, opts.network.backend).with_str(name.as_str_lossy())?;
+                    let config = InterfaceConfig::from_interface(&opts.config_dir, &name)?;
+
+                    Ok(Some((device, store, config)))
+                },
                 // Skip WireGuard interfaces that aren't managed by innernet.
-                Err(e) if e.kind() == io::ErrorKind::NotFound => return None,
+                Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
                 // Error on interfaces that *are* managed by innernet but are not readable.
-                Err(e) => return Some(Err(e.into())),
-            };
-
-            let fallible_things = || {
-                let device =
-                    Device::get(&name, opts.network.backend).with_str(name.as_str_lossy())?;
-                let config = InterfaceConfig::from_interface(&opts.config_dir, &name)?;
-
-                Ok((device, data_store, config))
-            };
-
-            Some(fallible_things())
+                Err(e) => Err(e.into()),
+            }
         })
+        // Filter out Ok(None).
+        .filter_map(Result::transpose)
         .collect::<Result<Vec<_>, _>>()?;
 
     if devices.is_empty() {

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -420,7 +420,7 @@ fn up(
 
 fn uninstall(interface: &InterfaceName, opts: &Opts, yes: bool) -> Result<(), Error> {
     let config = InterfaceConfig::get_path(&opts.config_dir, interface);
-    let data = DataStore::get_peers_and_cidrs_path(&opts.data_dir, interface);
+    let data = DataStore::get_path(&opts.data_dir, interface);
 
     if !config.exists() && !data.exists() {
         bail!(
@@ -445,7 +445,10 @@ fn uninstall(interface: &InterfaceName, opts: &Opts, yes: bool) -> Result<(), Er
             .with_path(&config)
             .map_err(|e| log::warn!("{}", e.to_string().yellow()))
             .ok();
-        DataStore::remove_files(&opts.data_dir, interface);
+        std::fs::remove_file(&data)
+            .with_path(&data)
+            .map_err(|e| log::warn!("{}", e.to_string().yellow()))
+            .ok();
         log::info!(
             "network {} is uninstalled.",
             interface.as_str_lossy().yellow()
@@ -537,10 +540,14 @@ fn delete_cidr(
 
 fn list_cidrs(interface: &InterfaceName, opts: &Opts, tree: bool) -> Result<(), Error> {
     let data_store = DataStore::open(&opts.data_dir, interface)?;
+
+    // TODO(bschwind) - Get this from InterfaceConfig.
+    let endpoint_has_local_override = false;
+
     if tree {
         let cidr_tree = CidrTree::new(data_store.cidrs());
         colored::control::set_override(false);
-        print_tree(&cidr_tree, &[], 0, false, &data_store);
+        print_tree(&cidr_tree, &[], 0, false, endpoint_has_local_override);
         colored::control::unset_override();
     } else {
         for cidr in data_store.cidrs() {
@@ -960,12 +967,21 @@ fn show(opts: &Opts, short: bool, tree: bool, interface: Option<Interface>) -> R
         peer_states.sort_by_key(|peer| peer.peer.ip);
         let verbose = opts.verbose > 0;
 
+        // TODO(bschwind) - Get this from InterfaceConfig.
+        let endpoint_has_local_override = false;
+
         if tree {
             let cidr_tree = CidrTree::new(cidrs);
-            print_tree(&cidr_tree, &peer_states, 1, verbose, &store);
+            print_tree(
+                &cidr_tree,
+                &peer_states,
+                1,
+                verbose,
+                endpoint_has_local_override,
+            );
         } else {
             for peer_state in peer_states {
-                print_peer(&peer_state, short, 1, verbose, &store);
+                print_peer(&peer_state, short, 1, verbose, endpoint_has_local_override);
             }
         }
     }
@@ -977,7 +993,7 @@ fn print_tree(
     peers: &[PeerState],
     level: usize,
     verbose: bool,
-    data_store: &DataStore,
+    endpoint_has_local_override: bool,
 ) {
     println_pad!(
         level * 2,
@@ -988,12 +1004,18 @@ fn print_tree(
 
     let mut children: Vec<_> = cidr.children().collect();
     children.sort();
-    children
-        .iter()
-        .for_each(|child| print_tree(child, peers, level + 1, verbose, data_store));
+    children.iter().for_each(|child| {
+        print_tree(
+            child,
+            peers,
+            level + 1,
+            verbose,
+            endpoint_has_local_override,
+        )
+    });
 
     for peer in peers.iter().filter(|p| p.peer.cidr_id == cidr.id) {
-        print_peer(peer, true, level, verbose, data_store);
+        print_peer(peer, true, level, verbose, endpoint_has_local_override);
     }
 }
 
@@ -1021,7 +1043,13 @@ fn print_interface(device_info: &Device, short: bool) -> Result<(), Error> {
     Ok(())
 }
 
-fn print_peer(peer: &PeerState, short: bool, level: usize, verbose: bool, data_store: &DataStore) {
+fn print_peer(
+    peer: &PeerState,
+    short: bool,
+    level: usize,
+    verbose: bool,
+    endpoint_has_local_override: bool,
+) {
     let pad = level * 2;
     let PeerState { peer, info } = peer;
     let public_key = if verbose {
@@ -1030,7 +1058,6 @@ fn print_peer(peer: &PeerState, short: bool, level: usize, verbose: bool, data_s
         &format!("{}…", &peer.public_key[..10])
     };
 
-    let endpoint_has_local_override = data_store.endpoint_override_for_peer(peer.ip).is_some();
     let endpoint_override_msg = if endpoint_has_local_override {
         " (endpoint overridden locally)"
     } else {

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -798,9 +798,11 @@ fn override_peer_endpoint(
 
     let mut data_store = DataStore::open(&opts.data_dir, interface)?;
 
-    if let Some((peer_ip, peer_pub_key, endpoint_opt)) =
-        prompts::override_peer_endpoint_prompt(data_store.peers(), &sub_opts)?
-    {
+    if let Some((peer_ip, peer_pub_key, endpoint_opt)) = prompts::override_peer_endpoint_prompt(
+        data_store.peers(),
+        data_store.local_endpoint_overrides(),
+        &sub_opts,
+    )? {
         if let Some(endpoint) = endpoint_opt {
             log::info!(
                 "overriding endpoint for peer IP {} with endpoint {}",

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -792,11 +792,12 @@ fn override_peer_endpoint(
     opts: &Opts,
     sub_opts: OverridePeerEndpointOpts,
 ) -> Result<(), Error> {
-    let mut data_store = DataStore::open(&opts.data_dir, interface)?;
+    let mut config = InterfaceConfig::from_interface(&opts.config_dir, interface)?;
+    let data_store = DataStore::open(&opts.data_dir, interface)?;
 
     if let Some((peer, endpoint_opt)) = prompts::override_peer_endpoint_prompt(
         data_store.peers(),
-        data_store.peer_endpoint_overrides(),
+        config.peer_endpoint_overrides(),
         &sub_opts,
     )? {
         if let Some(endpoint) = endpoint_opt {
@@ -805,7 +806,7 @@ fn override_peer_endpoint(
                 peer.ip,
                 endpoint
             );
-            data_store.set_endpoint_override_for_peer(peer.ip, endpoint.clone());
+            config.set_endpoint_override_for_peer(peer.ip, endpoint.clone());
 
             let socket_addr = endpoint.resolve()?;
             let peer_pub_key = Key::from_base64(&peer.public_key).unwrap();
@@ -818,12 +819,12 @@ fn override_peer_endpoint(
                 "unsetting endpoint override for peer IP {} with endpoint",
                 peer.ip
             );
-            data_store.unset_endpoint_override_for_peer(peer.ip);
+            config.unset_endpoint_override_for_peer(peer.ip);
 
             log::info!("normal peer endpoint/NAT traversal will be restored on the next call to 'innernet fetch'");
         }
 
-        data_store.write_peer_endpoint_overrides()?;
+        config.save(&opts.config_dir, interface)?;
     } else {
         log::info!("exiting without overriding peer endpoint");
     }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -821,10 +821,7 @@ fn override_peer_endpoint(
                 endpoint,
             )?;
         } else {
-            log::info!(
-                "unsetting endpoint override for peer IP {} with endpoint",
-                peer.ip
-            );
+            log::info!("unsetting endpoint override for peer IP {}", peer.ip);
 
             innernet_client_core::unset_endpoint_override_for_peer(
                 &opts.config_dir,

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -26,7 +26,7 @@ use std::{
     time::Duration,
 };
 use util::{human_duration, human_size};
-use wireguard_control::{Device, DeviceUpdate, InterfaceName, PeerConfigBuilder, PeerInfo};
+use wireguard_control::{Device, DeviceUpdate, InterfaceName, Key, PeerConfigBuilder, PeerInfo};
 
 mod util;
 
@@ -798,7 +798,7 @@ fn override_peer_endpoint(
 
     let mut data_store = DataStore::open(&opts.data_dir, interface)?;
 
-    if let Some((peer_ip, peer_pub_key, endpoint_opt)) = prompts::override_peer_endpoint_prompt(
+    if let Some((peer, endpoint_opt)) = prompts::override_peer_endpoint_prompt(
         data_store.peers(),
         data_store.local_endpoint_overrides(),
         &sub_opts,
@@ -806,12 +806,13 @@ fn override_peer_endpoint(
         if let Some(endpoint) = endpoint_opt {
             log::info!(
                 "overriding endpoint for peer IP {} with endpoint {}",
-                peer_ip,
+                peer.ip,
                 endpoint
             );
-            data_store.override_endpoint_for_peer(peer_ip, endpoint.clone());
+            data_store.override_endpoint_for_peer(peer.ip, endpoint.clone());
 
             let socket_addr = endpoint.resolve()?;
+            let peer_pub_key = Key::from_base64(&peer.public_key).unwrap();
 
             DeviceUpdate::new()
                 .add_peer(PeerConfigBuilder::new(&peer_pub_key).set_endpoint(socket_addr))
@@ -819,9 +820,9 @@ fn override_peer_endpoint(
         } else {
             log::info!(
                 "unsetting endpoint override for peer IP {} with endpoint",
-                peer_ip
+                peer.ip
             );
-            data_store.unset_endpoint_for_peer(peer_ip);
+            data_store.unset_endpoint_for_peer(peer.ip);
         }
 
         // TODO(bschwind) - Should we do NAT traversal too?

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -26,7 +26,7 @@ use std::{
     time::Duration,
 };
 use util::{human_duration, human_size};
-use wireguard_control::{Device, DeviceUpdate, InterfaceName, Key, PeerConfigBuilder, PeerInfo};
+use wireguard_control::{Device, InterfaceName, PeerInfo};
 
 mod util;
 
@@ -811,25 +811,30 @@ fn override_peer_endpoint(
                 peer.ip,
                 endpoint
             );
-            config.set_endpoint_override_for_peer(peer.ip, endpoint.clone());
 
-            let socket_addr = endpoint.resolve()?;
-            let peer_pub_key = Key::from_base64(&peer.public_key).unwrap();
-
-            DeviceUpdate::new()
-                .add_peer(PeerConfigBuilder::new(&peer_pub_key).set_endpoint(socket_addr))
-                .apply(interface, opts.network.backend)?;
+            innernet_client_core::set_endpoint_override_for_peer(
+                opts.network.backend,
+                &opts.config_dir,
+                interface,
+                &mut config,
+                &peer,
+                endpoint,
+            )?;
         } else {
             log::info!(
                 "unsetting endpoint override for peer IP {} with endpoint",
                 peer.ip
             );
-            config.unset_endpoint_override_for_peer(peer.ip);
+
+            innernet_client_core::unset_endpoint_override_for_peer(
+                &opts.config_dir,
+                interface,
+                &mut config,
+                &peer,
+            )?;
 
             log::info!("normal peer endpoint/NAT traversal will be restored on the next call to 'innernet fetch'");
         }
-
-        config.save(&opts.config_dir, interface)?;
     } else {
         log::info!("exiting without overriding peer endpoint");
     }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -795,13 +795,11 @@ fn override_peer_endpoint(
     opts: &Opts,
     sub_opts: OverridePeerEndpointOpts,
 ) -> Result<(), Error> {
-    let _config = InterfaceConfig::from_interface(&opts.config_dir, interface)?;
-
     let mut data_store = DataStore::open(&opts.data_dir, interface)?;
 
     if let Some((peer, endpoint_opt)) = prompts::override_peer_endpoint_prompt(
         data_store.peers(),
-        data_store.local_endpoint_overrides(),
+        data_store.peer_endpoint_overrides(),
         &sub_opts,
     )? {
         if let Some(endpoint) = endpoint_opt {
@@ -824,6 +822,8 @@ fn override_peer_endpoint(
                 peer.ip
             );
             data_store.unset_endpoint_for_peer(peer.ip);
+
+            log::info!("normal peer endpoint/NAT traversal will be restored on the next call to 'innernet fetch'");
         }
 
         // TODO(bschwind) - Should we do NAT traversal too?
@@ -1036,7 +1036,7 @@ fn print_peer(peer: &PeerState, short: bool, level: usize, verbose: bool, data_s
 
     let endpoint_has_local_override = data_store.endpoint_override_for_peer(peer.ip).is_some();
     let endpoint_override_msg = if endpoint_has_local_override {
-        " (local endpoint override)"
+        " (endpoint overridden locally)"
     } else {
         ""
     };
@@ -1049,7 +1049,7 @@ fn print_peer(peer: &PeerState, short: bool, level: usize, verbose: bool, data_s
 
         println_pad!(
             pad,
-            "| {} {}: {} ({}{}){}",
+            "| {} {}: {} ({}{}){endpoint_override_msg}",
             if connected || is_you {
                 "◉".bold()
             } else {
@@ -1059,7 +1059,6 @@ fn print_peer(peer: &PeerState, short: bool, level: usize, verbose: bool, data_s
             peer.name.yellow(),
             if is_you { "you, " } else { "" },
             public_key.dimmed(),
-            endpoint_override_msg,
         );
     } else {
         println_pad!(
@@ -1074,10 +1073,8 @@ fn print_peer(peer: &PeerState, short: bool, level: usize, verbose: bool, data_s
             if let Some(endpoint) = info.config.endpoint {
                 println_pad!(
                     pad,
-                    "  {}: {}{}",
+                    "  {}: {endpoint}{endpoint_override_msg}",
                     "endpoint".bold(),
-                    endpoint,
-                    endpoint_override_msg
                 );
             }
             if let Some(last_handshake) = info.stats.last_handshake_time {

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -826,8 +826,6 @@ fn override_peer_endpoint(
             log::info!("normal peer endpoint/NAT traversal will be restored on the next call to 'innernet fetch'");
         }
 
-        // TODO(bschwind) - Should we do NAT traversal too?
-
         data_store.write()?;
     } else {
         log::info!("exiting without overriding peer endpoint");

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -420,7 +420,7 @@ fn up(
 
 fn uninstall(interface: &InterfaceName, opts: &Opts, yes: bool) -> Result<(), Error> {
     let config = InterfaceConfig::get_path(&opts.config_dir, interface);
-    let data = DataStore::get_path(&opts.data_dir, interface);
+    let data = DataStore::get_peers_and_cidrs_path(&opts.data_dir, interface);
 
     if !config.exists() && !data.exists() {
         bail!(
@@ -445,10 +445,7 @@ fn uninstall(interface: &InterfaceName, opts: &Opts, yes: bool) -> Result<(), Er
             .with_path(&config)
             .map_err(|e| log::warn!("{}", e.to_string().yellow()))
             .ok();
-        std::fs::remove_file(&data)
-            .with_path(&data)
-            .map_err(|e| log::warn!("{}", e.to_string().yellow()))
-            .ok();
+        DataStore::remove_files(&opts.data_dir, interface);
         log::info!(
             "network {} is uninstalled.",
             interface.as_str_lossy().yellow()
@@ -821,12 +818,12 @@ fn override_peer_endpoint(
                 "unsetting endpoint override for peer IP {} with endpoint",
                 peer.ip
             );
-            data_store.unset_endpoint_for_peer(peer.ip);
+            data_store.unset_endpoint_override_for_peer(peer.ip);
 
             log::info!("normal peer endpoint/NAT traversal will be restored on the next call to 'innernet fetch'");
         }
 
-        data_store.write()?;
+        data_store.write_peer_endpoint_overrides()?;
     } else {
         log::info!("exiting without overriding peer endpoint");
     }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -253,6 +253,7 @@ enum Command {
         sub_opts: OverrideEndpointOpts,
     },
 
+    /// Override the endpoint you use to connect to a particular peer
     OverridePeerEndpoint {
         interface: Interface,
 

--- a/shared/src/interface_config.rs
+++ b/shared/src/interface_config.rs
@@ -3,9 +3,10 @@ use indoc::writedoc;
 use ipnet::IpNet;
 use serde::{Deserialize, Serialize};
 use std::{
+    collections::BTreeMap,
     fs::{File, OpenOptions},
     io::{self, Write},
-    net::SocketAddr,
+    net::{IpAddr, SocketAddr},
     path::{Path, PathBuf},
 };
 use wireguard_control::{InterfaceName, KeyPair};
@@ -20,6 +21,12 @@ pub struct InterfaceConfig {
 
     /// The necessary contact information for the server.
     pub server: ServerInfo,
+
+    /// A configurable map of peer IP addresses to Endpoints which should
+    /// be used as the WireGuard endpoint for that peer.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    peer_endpoint_overrides: BTreeMap<IpAddr, Endpoint>,
 }
 
 #[derive(Clone, Deserialize, Serialize, Debug)]
@@ -77,6 +84,14 @@ impl ServerInfo {
 }
 
 impl InterfaceConfig {
+    fn new(interface: InterfaceInfo, server: ServerInfo) -> Self {
+        InterfaceConfig {
+            interface,
+            server,
+            peer_endpoint_overrides: BTreeMap::new(),
+        }
+    }
+
     /// Save a new config file, failing if it already exists.
     pub fn save_new(&self, path: impl AsRef<Path>, mode: u32) -> Result<(), WrappedIoError> {
         let path = path.as_ref();
@@ -133,8 +148,16 @@ impl InterfaceConfig {
         Ok(Self::get_path(config_dir, interface))
     }
 
-    fn new(interface: InterfaceInfo, server: ServerInfo) -> Self {
-        InterfaceConfig { interface, server }
+    pub fn peer_endpoint_overrides(&self) -> &BTreeMap<IpAddr, Endpoint> {
+        &self.peer_endpoint_overrides
+    }
+
+    pub fn set_endpoint_override_for_peer(&mut self, peer_ip: IpAddr, endpoint: Endpoint) {
+        self.peer_endpoint_overrides.insert(peer_ip, endpoint);
+    }
+
+    pub fn unset_endpoint_override_for_peer(&mut self, peer_ip: IpAddr) {
+        self.peer_endpoint_overrides.remove(&peer_ip);
     }
 }
 

--- a/shared/src/prompts.rs
+++ b/shared/src/prompts.rs
@@ -617,6 +617,8 @@ pub fn override_peer_endpoint_prompt(
 
     let endpoint: Option<Endpoint> = if args.unset {
         None
+    } else if let Some(endpoint) = &args.endpoint {
+        Some(endpoint.clone())
     } else {
         Some(input("Endpoint", Prefill::None)?)
     };

--- a/shared/src/prompts.rs
+++ b/shared/src/prompts.rs
@@ -601,7 +601,7 @@ pub fn override_peer_endpoint_prompt(
             .clone()
     } else {
         let message = if args.unset {
-            "Peer endpoint to unset"
+            "Peer endpoint override to unset"
         } else {
             "Peer endpoint to override"
         };

--- a/shared/src/prompts.rs
+++ b/shared/src/prompts.rs
@@ -4,7 +4,7 @@ use crate::{
     Endpoint, Error, Hostname, IpNetExt, ListenPortOpts, OverridePeerEndpointOpts, Peer,
     PeerContents, RenameCidrOpts, RenamePeerOpts,
 };
-use anyhow::anyhow;
+use anyhow::{anyhow, bail};
 use colored::*;
 use dialoguer::{theme::ColorfulTheme, Confirm, Input, Select};
 use innernet_publicip::Preference;
@@ -584,23 +584,22 @@ pub fn override_peer_endpoint_prompt(
         .filter(|p| !args.unset || peer_endpoint_overrides.contains_key(&p.ip))
         .collect::<Vec<_>>();
 
-    if args.unset && eligible_peers.is_empty() {
-        return Err(anyhow!("No peers have an override endpoint set"));
-    }
-
     let peer = if let Some(name) = &args.name {
-        eligible_peers
-            .into_iter()
-            .find(|p| &p.name == name)
-            .ok_or_else(|| {
-                anyhow!(
-                    "Peer '{}' does not exist or does not have an override set",
-                    name
-                )
-            })?
-            .clone()
+        let Some(peer) = eligible_peers.into_iter().find(|p| &p.name == name) else {
+            return if args.unset && peers.iter().find(|p| &p.name == name).is_some() {
+                log::info!("Peer '{name}' does not have an override set");
+                Ok(None)
+            } else {
+                Err(anyhow!("Peer '{name}' does not exist"))
+            };
+        };
+        peer.clone()
     } else {
         let message = if args.unset {
+            if eligible_peers.is_empty() {
+                bail!("No peers have an override endpoint set");
+            }
+
             "Peer endpoint override to unset"
         } else {
             "Peer endpoint to override"

--- a/shared/src/prompts.rs
+++ b/shared/src/prompts.rs
@@ -16,7 +16,6 @@ use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     str::FromStr,
 };
-use wireguard_control::Key;
 
 pub static THEME: Lazy<ColorfulTheme> = Lazy::new(ColorfulTheme::default);
 
@@ -576,7 +575,7 @@ pub fn override_peer_endpoint_prompt(
     peers: &[Peer],
     peer_endpoint_overrides: &HashMap<IpAddr, Endpoint>,
     args: &OverridePeerEndpointOpts,
-) -> Result<Option<(IpAddr, Key, Option<Endpoint>)>, Error> {
+) -> Result<Option<(Peer, Option<Endpoint>)>, Error> {
     let eligible_peers = peers
         .iter()
         .filter(|p| &*p.name != "innernet-server")
@@ -639,11 +638,7 @@ pub fn override_peer_endpoint_prompt(
     };
 
     Ok(if args.yes || confirm(confirm_msg)? {
-        Some((
-            peer.ip,
-            Key::from_base64(&peer.public_key).unwrap(),
-            endpoint,
-        ))
+        Some((peer, endpoint))
     } else {
         None
     })

--- a/shared/src/prompts.rs
+++ b/shared/src/prompts.rs
@@ -10,6 +10,7 @@ use dialoguer::{theme::ColorfulTheme, Confirm, Input, Select};
 use innernet_publicip::Preference;
 use once_cell::sync::Lazy;
 use std::{
+    collections::HashMap,
     fmt::{Debug, Display},
     io,
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -573,18 +574,31 @@ pub fn input_external_endpoint(
 /// Returns the peer IP, peer public key, and desired endpoint.
 pub fn override_peer_endpoint_prompt(
     peers: &[Peer],
+    peer_endpoint_overrides: &HashMap<IpAddr, Endpoint>,
     args: &OverridePeerEndpointOpts,
 ) -> Result<Option<(IpAddr, Key, Option<Endpoint>)>, Error> {
     let eligible_peers = peers
         .iter()
         .filter(|p| &*p.name != "innernet-server")
+        // If we're unsetting, filter eligible_peers to just be peers that have
+        // an override already set.
+        .filter(|p| !args.unset || peer_endpoint_overrides.contains_key(&p.ip))
         .collect::<Vec<_>>();
+
+    if args.unset && eligible_peers.is_empty() {
+        return Err(anyhow!("No peers have an override endpoint set"));
+    }
 
     let peer = if let Some(ref name) = args.name {
         eligible_peers
             .into_iter()
             .find(|p| &p.name == name)
-            .ok_or_else(|| anyhow!("Peer '{}' does not exist", name))?
+            .ok_or_else(|| {
+                anyhow!(
+                    "Peer '{}' does not exist or does not have an override set",
+                    name
+                )
+            })?
             .clone()
     } else {
         let message = if args.unset {
@@ -592,9 +606,6 @@ pub fn override_peer_endpoint_prompt(
         } else {
             "Peer endpoint to override"
         };
-
-        // TODO(bschwind) - If we're unsetting, filter eligible_peers to just
-        //                  be peers that have an override already set.
 
         let (peer_index, _) = select(
             message,

--- a/shared/src/prompts.rs
+++ b/shared/src/prompts.rs
@@ -1,8 +1,8 @@
 use crate::{
     interface_config::InterfaceInfo, peer::NewPeerInfo, AddCidrOpts, AddDeleteAssociationOpts,
     AddPeerOpts, Association, Cidr, CidrContents, CidrTree, DeleteCidrOpts, EnableDisablePeerOpts,
-    Endpoint, Error, Hostname, IpNetExt, ListenPortOpts, Peer, PeerContents, RenameCidrOpts,
-    RenamePeerOpts,
+    Endpoint, Error, Hostname, IpNetExt, ListenPortOpts, OverridePeerEndpointOpts, Peer,
+    PeerContents, RenameCidrOpts, RenamePeerOpts,
 };
 use anyhow::anyhow;
 use colored::*;
@@ -15,6 +15,7 @@ use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     str::FromStr,
 };
+use wireguard_control::Key;
 
 pub static THEME: Lazy<ColorfulTheme> = Lazy::new(ColorfulTheme::default);
 
@@ -566,4 +567,70 @@ pub fn input_external_endpoint(
     )?;
 
     Ok(endpoint)
+}
+
+/// Bring up a prompt to override the endpoint for an existing peer.
+/// Returns the peer IP, peer public key, and desired endpoint.
+pub fn override_peer_endpoint_prompt(
+    peers: &[Peer],
+    args: &OverridePeerEndpointOpts,
+) -> Result<Option<(IpAddr, Key, Option<Endpoint>)>, Error> {
+    let eligible_peers = peers
+        .iter()
+        .filter(|p| &*p.name != "innernet-server")
+        .collect::<Vec<_>>();
+
+    let peer = if let Some(ref name) = args.name {
+        eligible_peers
+            .into_iter()
+            .find(|p| &p.name == name)
+            .ok_or_else(|| anyhow!("Peer '{}' does not exist", name))?
+            .clone()
+    } else {
+        let message = if args.unset {
+            "Peer endpoint to unset"
+        } else {
+            "Peer endpoint to override"
+        };
+
+        let (peer_index, _) = select(
+            message,
+            &eligible_peers
+                .iter()
+                .map(|ep| ep.name.clone())
+                .collect::<Vec<_>>(),
+        )?;
+        eligible_peers[peer_index].clone()
+    };
+
+    let endpoint: Option<Endpoint> = if args.unset {
+        None
+    } else {
+        Some(input("Endpoint", Prefill::None)?)
+    };
+
+    let confirm_msg = if let Some(endpoint) = &endpoint {
+        &format!(
+            "Override endpoint for peer {} ({}) to {}?",
+            peer.name.yellow(),
+            peer.ip,
+            endpoint,
+        )
+    } else {
+        &format!(
+            "Unset endpoint override for peer {} ({})?",
+            peer.name.yellow(),
+            peer.ip,
+        )
+    };
+
+    Ok(if args.yes || confirm(confirm_msg)? {
+        Some((
+            peer.ip,
+            Key::from_base64(&peer.public_key).unwrap(),
+            endpoint,
+        ))
+    } else {
+        None
+    })
 }

--- a/shared/src/prompts.rs
+++ b/shared/src/prompts.rs
@@ -593,6 +593,9 @@ pub fn override_peer_endpoint_prompt(
             "Peer endpoint to override"
         };
 
+        // TODO(bschwind) - If we're unsetting, filter eligible_peers to just
+        //                  be peers that have an override already set.
+
         let (peer_index, _) = select(
             message,
             &eligible_peers

--- a/shared/src/prompts.rs
+++ b/shared/src/prompts.rs
@@ -570,7 +570,7 @@ pub fn input_external_endpoint(
 }
 
 /// Bring up a prompt to override the endpoint for an existing peer.
-/// Returns the peer IP, peer public key, and desired endpoint.
+/// Returns the peer and desired endpoint.
 pub fn override_peer_endpoint_prompt(
     peers: &[Peer],
     peer_endpoint_overrides: &HashMap<IpAddr, Endpoint>,

--- a/shared/src/prompts.rs
+++ b/shared/src/prompts.rs
@@ -10,7 +10,7 @@ use dialoguer::{theme::ColorfulTheme, Confirm, Input, Select};
 use innernet_publicip::Preference;
 use once_cell::sync::Lazy;
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
     fmt::{Debug, Display},
     io,
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -76,7 +76,7 @@ where
 
 /// Bring up a prompt to create a new CIDR. Returns the peer request.
 pub fn add_cidr(cidrs: &[Cidr], request: &AddCidrOpts) -> Result<Option<CidrContents>, Error> {
-    let parent_cidr = if let Some(ref parent_name) = request.parent {
+    let parent_cidr = if let Some(parent_name) = &request.parent {
         cidrs
             .iter()
             .find(|cidr| &cidr.name == parent_name)
@@ -85,7 +85,7 @@ pub fn add_cidr(cidrs: &[Cidr], request: &AddCidrOpts) -> Result<Option<CidrCont
         choose_cidr(cidrs, "Parent CIDR")?
     };
 
-    let name = if let Some(ref name) = request.name {
+    let name = if let Some(name) = &request.name {
         name.clone()
     } else {
         input("Name", Prefill::None)?
@@ -117,7 +117,7 @@ pub fn rename_cidr(
     cidrs: &[Cidr],
     args: &RenameCidrOpts,
 ) -> Result<Option<(CidrContents, String)>, Error> {
-    let old_cidr = if let Some(ref name) = args.name {
+    let old_cidr = if let Some(name) = &args.name {
         cidrs
             .iter()
             .find(|c| &c.name == name)
@@ -131,7 +131,7 @@ pub fn rename_cidr(
         cidrs[cidr_index].clone()
     };
     let old_name = old_cidr.name.clone();
-    let new_name = if let Some(ref name) = args.new_name {
+    let new_name = if let Some(name) = &args.new_name {
         name.clone()
     } else {
         input("New Name", Prefill::None)?
@@ -166,7 +166,7 @@ pub fn delete_cidr(cidrs: &[Cidr], peers: &[Peer], request: &DeleteCidrOpts) -> 
             )
         })
         .collect();
-    let cidr = if let Some(ref name) = request.name {
+    let cidr = if let Some(name) = &request.name {
         cidrs
             .iter()
             .find(|cidr| &cidr.name == name)
@@ -311,7 +311,7 @@ pub fn gather_new_peer_info(
 ) -> Result<Option<(NewPeerInfo, String)>, Error> {
     let leaves = cidr_tree.leaves();
 
-    let cidr = if let Some(ref parent_name) = args.cidr {
+    let cidr = if let Some(parent_name) = &args.cidr {
         leaves
             .iter()
             .find(|cidr| &cidr.name == parent_name)
@@ -339,7 +339,7 @@ pub fn gather_new_peer_info(
         input("IP", Prefill::Default(available_ip))?
     };
 
-    let name = if let Some(ref name) = args.name {
+    let name = if let Some(name) = &args.name {
         name.clone()
     } else {
         input("Name", Prefill::None)?
@@ -351,7 +351,7 @@ pub fn gather_new_peer_info(
         confirm(&format!("Make {name} an admin?"))?
     };
 
-    let invite_expires = if let Some(ref invite_expires) = args.invite_expires {
+    let invite_expires = if let Some(invite_expires) = &args.invite_expires {
         invite_expires.clone()
     } else {
         input(
@@ -360,7 +360,7 @@ pub fn gather_new_peer_info(
         )?
     };
 
-    let invite_save_path = if let Some(ref location) = args.save_config {
+    let invite_save_path = if let Some(location) = &args.save_config {
         location.clone()
     } else {
         input(
@@ -393,7 +393,7 @@ pub fn rename_peer(
         .iter()
         .filter(|p| &*p.name != "innernet-server")
         .collect::<Vec<_>>();
-    let old_peer = if let Some(ref name) = args.name {
+    let old_peer = if let Some(name) = &args.name {
         eligible_peers
             .into_iter()
             .find(|p| &p.name == name)
@@ -410,7 +410,7 @@ pub fn rename_peer(
         eligible_peers[peer_index].clone()
     };
     let old_name = old_peer.name.clone();
-    let new_name = if let Some(ref name) = args.new_name {
+    let new_name = if let Some(name) = &args.new_name {
         name.clone()
     } else {
         input("New Name", Prefill::None)?
@@ -446,7 +446,7 @@ pub fn enable_or_disable_peer(
         .filter(|peer| enable && peer.is_disabled || !enable && !peer.is_disabled)
         .collect();
 
-    let peer = if let Some(ref name) = args.name {
+    let peer = if let Some(name) = &args.name {
         enabled_peers
             .into_iter()
             .find(|p| &p.name == name)
@@ -573,7 +573,7 @@ pub fn input_external_endpoint(
 /// Returns the peer and desired endpoint.
 pub fn override_peer_endpoint_prompt(
     peers: &[Peer],
-    peer_endpoint_overrides: &HashMap<IpAddr, Endpoint>,
+    peer_endpoint_overrides: &BTreeMap<IpAddr, Endpoint>,
     args: &OverridePeerEndpointOpts,
 ) -> Result<Option<(Peer, Option<Endpoint>)>, Error> {
     let eligible_peers = peers
@@ -588,7 +588,7 @@ pub fn override_peer_endpoint_prompt(
         return Err(anyhow!("No peers have an override endpoint set"));
     }
 
-    let peer = if let Some(ref name) = args.name {
+    let peer = if let Some(name) = &args.name {
         eligible_peers
             .into_iter()
             .find(|p| &p.name == name)

--- a/shared/src/types.rs
+++ b/shared/src/types.rs
@@ -469,6 +469,25 @@ pub struct OverrideEndpointOpts {
     pub yes: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Args)]
+pub struct OverridePeerEndpointOpts {
+    /// Name of peer whose endpoint you want to override
+    #[clap(long)]
+    pub name: Option<Hostname>,
+
+    /// The external endpoint that you'd like to use for a given peer
+    #[clap(short, long)]
+    pub endpoint: Option<Endpoint>,
+
+    /// Unset an existing local endpoint override for this peer
+    #[clap(short, long, conflicts_with = "endpoint")]
+    pub unset: bool,
+
+    /// Bypass confirmation
+    #[clap(long)]
+    pub yes: bool,
+}
+
 #[derive(Debug, Clone, Args)]
 pub struct NatOpts {
     #[clap(long)]


### PR DESCRIPTION
Related to #314

This lets an innernet client specify a particular endpoint to use for a peer.

Motivating example: When running a relay like [wpex](https://github.com/weiiwang01/wpex), you must specify the _relay endpoint_ as the endpoint for the peer you want to talk to over the relay, and they must do the same for your peer.

To set an override:

```
$ sudo innernet override-peer-endpoint <INTERFACE_NAME>
```

`name` and `endpoint` can also be specified, along with a `--yes` flag to bypass confirmation:

```
$ sudo innernet override-peer-endpoint <INTERFACE_NAME> --name <PEER_NAME> --endpoint <ENDPOINT> --yes
```

To unset an override:

```
$ sudo innernet override-peer-endpoint <INTERFACE_NAME> --unset
```

When unsetting, you can also use `--name` and the `--yes` flag.

```
$ sudo innernet override-peer-endpoint <INTERFACE_NAME> --unset --name <PEER_NAME> --yes
```

I ultimately decided to implement this by adding a simple `HashMap<IpAddr, Endpoint>` to the `InterfaceConfig`. At first I wanted something stored on `Peer`, but that type is shared with the server and everything else, where a "local peer override" doesn't really make sense. The server should not be involved or care at all if a client overrides a particular peer's endpoint.

When we override an endpoint, we immediately tell the wireguard device to set that endpoint for the peer. When `fetch`ing from the innernet server, we apply the overrides from the `InterfaceConfig` on the list of peers before showing a diff or doing any NAT traversal.

~~One open question: if the specified endpoint is not reachable, should we allow NAT traversal to run and potentially set the endpoint to something different which _is_ reachable? Or should it remain fixed on that specified endpoint override no matter what?~~

We've decided to skip NAT traversal if a given peer has an endpoint override in place.

## Testing
- [x] does `override-peer-endpoint` work when the respective interface is down?
- [x] try to unset a peer endpoint override that isn't set in the first, place specifycing `--name` on the command line. Return value should be 0.
- [x] NAT traversal is indeed skipped for peers with locally overriden endpoint (try with peer that is offline but has multiple candidates)
- [x] for peers A and B who cannot reach each other, their override-peer-endpoint to a `wpex` instance at both sides, they should connect immediately (even with no background `innernet fetch` / daemon)
  - [x] reboot peer A. The connection through wpex should resume after booting
  - [x] reboot both peers simultaneously, connection should resume
- [ ] for peers A and B that already have connection between each other, try to use `override-peer-endpoint` on both sides to route their traffic through wpex instance. Describe what happens. (they may "stick" to their existing endpoints)
  - [ ] if the endpoint was indeed sticky above, try `innernet down <interface>` first at both ends, then override peer endpoints