### PR TITLE
Include innernet_client_core in BASE_MODULES for logging

### DIFF
--- a/client/src/util.rs
+++ b/client/src/util.rs
@@ -7,7 +7,7 @@ use std::{ffi::OsStr, io, path::Path, time::Duration};
 static LOGGER: Logger = Logger;
 struct Logger;
 
-const BASE_MODULES: &[&str] = &["innernet", "innernet_shared"];
+const BASE_MODULES: &[&str] = &["innernet", "innernet_client_core", "innernet_shared"];
 
 fn target_is_base(target: &str) -> bool {
     BASE_MODULES


### PR DESCRIPTION
One thing I noticed when working on #395

When you run something simple like `innernet fetch`, it prints basically nothing. This is because a lot of the logic was moved to `innernet_client_core`, and that "module" gets filtered out by our logging logic.

This fixes it, though I also question whether `innernet_client_core` should even be in charge of logging user-facing messages like this. Usually the application layer that is using the "core" library would be the one to print those messages.