### PR TITLE
Print full public keys with global --verbose flag; unify truncation length to 10 chars

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -984,7 +984,7 @@ fn print_peer(peer: &PeerState, short: bool, level: usize) {
             peer.ip.to_string().yellow().bold(),
             peer.name.yellow(),
             if is_you { "you, " } else { "" },
-            &peer.public_key[..6].dimmed(),
+            &peer.public_key[..10].dimmed(),
         );
     } else {
         println_pad!(

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -534,7 +534,7 @@ fn list_cidrs(interface: &InterfaceName, opts: &Opts, tree: bool) -> Result<(), 
     if tree {
         let cidr_tree = CidrTree::new(data_store.cidrs());
         colored::control::set_override(false);
-        print_tree(&cidr_tree, &[], 0);
+        print_tree(&cidr_tree, &[], 0, false);
         colored::control::unset_override();
     } else {
         for cidr in data_store.cidrs() {
@@ -907,20 +907,21 @@ fn show(opts: &Opts, short: bool, tree: bool, interface: Option<Interface>) -> R
 
         print_interface(&device_info, short || tree)?;
         peer_states.sort_by_key(|peer| peer.peer.ip);
+        let verbose = opts.verbose > 0;
 
         if tree {
             let cidr_tree = CidrTree::new(cidrs);
-            print_tree(&cidr_tree, &peer_states, 1);
+            print_tree(&cidr_tree, &peer_states, 1, verbose);
         } else {
             for peer_state in peer_states {
-                print_peer(&peer_state, short, 1);
+                print_peer(&peer_state, short, 1, verbose);
             }
         }
     }
     Ok(())
 }
 
-fn print_tree(cidr: &CidrTree, peers: &[PeerState], level: usize) {
+fn print_tree(cidr: &CidrTree, peers: &[PeerState], level: usize, verbose: bool) {
     println_pad!(
         level * 2,
         "{} {}",
@@ -932,10 +933,10 @@ fn print_tree(cidr: &CidrTree, peers: &[PeerState], level: usize) {
     children.sort();
     children
         .iter()
-        .for_each(|child| print_tree(child, peers, level + 1));
+        .for_each(|child| print_tree(child, peers, level + 1, verbose));
 
     for peer in peers.iter().filter(|p| p.peer.cidr_id == cidr.id) {
-        print_peer(peer, true, level);
+        print_peer(peer, true, level, verbose);
     }
 }
 
@@ -963,9 +964,14 @@ fn print_interface(device_info: &Device, short: bool) -> Result<(), Error> {
     Ok(())
 }
 
-fn print_peer(peer: &PeerState, short: bool, level: usize) {
+fn print_peer(peer: &PeerState, short: bool, level: usize, verbose: bool) {
     let pad = level * 2;
     let PeerState { peer, info } = peer;
+    let public_key = if verbose {
+        &peer.public_key
+    } else {
+        &format!("{}…", &peer.public_key[..10])
+    };
     if short {
         let connected = info
             .map(|info| info.is_recently_connected())
@@ -975,7 +981,7 @@ fn print_peer(peer: &PeerState, short: bool, level: usize) {
 
         println_pad!(
             pad,
-            "| {} {}: {} ({}{}…)",
+            "| {} {}: {} ({}{})",
             if connected || is_you {
                 "◉".bold()
             } else {
@@ -984,15 +990,15 @@ fn print_peer(peer: &PeerState, short: bool, level: usize) {
             peer.ip.to_string().yellow().bold(),
             peer.name.yellow(),
             if is_you { "you, " } else { "" },
-            &peer.public_key[..10].dimmed(),
+            public_key.dimmed(),
         );
     } else {
         println_pad!(
             pad,
-            "{}: {} ({}...)",
+            "{}: {} ({})",
             "peer".yellow().bold(),
             peer.name.yellow(),
-            &peer.public_key[..10].yellow(),
+            public_key.yellow(),
         );
         println_pad!(pad, "  {}: {}", "ip".bold(), peer.ip);
         if let Some(info) = info {


### PR DESCRIPTION
See the commits for details. This is a second attempt after #398 


- [Unify public-key truncation length to 10 chars in show](https://github.com/tonarino/innernet/commit/1bccb0bab74e7e3eb968d0c95f3836c1a8403b3f)
    The `--short` mode previously truncated public keys to 6 characters while the default mode used 10. Change both to consistently show 10 characters.
- [Print full public keys with global --verbose flag](https://github.com/tonarino/innernet/commit/ee8e0ebd6fd9167d5df4821c8f03be3d0a4cb843)
    When `innernet -v show` is used (or `-vv` etc.), print peers' public keys in full instead of truncating to 10 characters. Apply this regardless of the `-s`/`--short` or `-t`/`--tree` subcommand flags.

Resolves https://github.com/tonarino/innernet/issues/344

I've tested this locally.

Co-authored-by: opencode (big-pickle) <agent@opencode.ai>
Prompts used:
  - unify the length to which the public key is truncated in the show subcommand when called with --short and without (currently it is 6 and 10 characters respectively), make it 10 unconditionally.
  - commit the changes, write a nice commit message including a disclosure that this was written by an agent and include the prompts used in this session so far
  - make the global innernet -v/--verbose option print the wireguard public keys in full rather then truncating them as it is doing now when calling the show subcommand. It should work regardless of whether the -t or -s show flags are set or not.
  - dont print the key in print_interface
  - make the code more DRY by only defining the key variable once. Also name it public_key
  - verify with cargo clippy and cargo fmt
  - commit the changes. Mention this resolves https://github.com/tonarino/innernet/issues/344. Include a disclosure of ai use including all prompts used since the last commit.
