### PR TITLE
Prevent `last handshake: 495224 hours ago`

### DIFF
--- a/wireguard-control/src/backends/kernel.rs
+++ b/wireguard-control/src/backends/kernel.rs
@@ -22,7 +22,7 @@ use netlink_packet_wireguard::{
 };
 use netlink_request::{max_genl_payload_length, netlink_request_genl, netlink_request_rtnl};
 
-use std::{convert::TryFrom, io, time::SystemTime};
+use std::{convert::TryFrom, io, time::UNIX_EPOCH};
 
 macro_rules! get_nla_value {
     ($nlas:expr, $e:ident, $v:ident) => {
@@ -105,7 +105,7 @@ impl TryFrom<WgPeer> for PeerInfo {
             .map(AllowedIp::try_from)
             .collect::<Result<Vec<_>, _>>()?;
         let last_handshake_time = get_nla_value!(attrs, WgPeerAttrs, LastHandshake)
-            .filter(|&&time| time != SystemTime::UNIX_EPOCH)
+            .filter(|&&time| time != UNIX_EPOCH)
             .cloned();
         let rx_bytes = get_nla_value!(attrs, WgPeerAttrs, RxBytes)
             .cloned()

--- a/wireguard-control/src/backends/kernel.rs
+++ b/wireguard-control/src/backends/kernel.rs
@@ -22,7 +22,7 @@ use netlink_packet_wireguard::{
 };
 use netlink_request::{max_genl_payload_length, netlink_request_genl, netlink_request_rtnl};
 
-use std::{convert::TryFrom, io};
+use std::{convert::TryFrom, io, time::SystemTime};
 
 macro_rules! get_nla_value {
     ($nlas:expr, $e:ident, $v:ident) => {
@@ -104,7 +104,9 @@ impl TryFrom<WgPeer> for PeerInfo {
             .into_iter()
             .map(AllowedIp::try_from)
             .collect::<Result<Vec<_>, _>>()?;
-        let last_handshake_time = get_nla_value!(attrs, WgPeerAttrs, LastHandshake).cloned();
+        let last_handshake_time = get_nla_value!(attrs, WgPeerAttrs, LastHandshake)
+            .filter(|&&time| time != SystemTime::UNIX_EPOCH)
+            .cloned();
         let rx_bytes = get_nla_value!(attrs, WgPeerAttrs, RxBytes)
             .cloned()
             .unwrap_or_default();


### PR DESCRIPTION
...on Linux with the kernel driver.

- fixes https://github.com/tonarino/innernet/issues/341

It turns out that netlink returns valid but zero timestamp when where was no known handshake:
```
[wireguard-control/src/backends/kernel.rs:108:9] last_handshake_time = Some(
    SystemTime {
        tv_sec: 0,
        tv_nsec: 0,
    },
)
[wireguard-control/src/backends/kernel.rs:108:9] last_handshake_time = Some(
    SystemTime {
        tv_sec: 1782806981,
        tv_nsec: 354865888,
    },
)
[wireguard-control/src/backends/kernel.rs:108:9] last_handshake_time = Some(
    SystemTime {
        tv_sec: 0,
        tv_nsec: 0,
    },
)
```

## Before
```
  peer: annex-dev-machine (dwtawhdlRD...)
    ip: 10.42.64.22
    endpoint: 192.168.1.113:54151
    last handshake: 495224 hours, 15 minutes ago
    transfer: 0 B received, 840.45 KiB sent
  peer: brian-m1p (bvjPBfidEZ...)
    ip: 10.42.64.27
    endpoint: 1.2.3.4:51820
    last handshake: 48 hours, 6 minutes ago
    transfer: 4.18 KiB received, 791.33 KiB sent
  peer: jen (wNRA4Xh/Nh...)
    ip: 10.42.64.28
    endpoint: 3.4.5.6:52987
    last handshake: 1 minute, 39 seconds ago
    transfer: 36.46 KiB received, 515.46 KiB sent
```

## After
```
  peer: annex-dev-machine (dwtawhdlRD…)
    ip: 10.42.64.22
    endpoint: 192.168.1.113:54151
    transfer: 0 B received, 845.36 KiB sent
  peer: brian-m1p (bvjPBfidEZ…)
    ip: 10.42.64.27
    endpoint: 1.2.3.4:51820
    last handshake: 48 hours, 10 minutes ago
    transfer: 4.18 KiB received, 796.39 KiB sent
  peer: jen (wNRA4Xh/Nh…)
    ip: 10.42.64.28
    endpoint: 3.4.5.6:52987
    last handshake: 55 seconds ago
    transfer: 37.09 KiB received, 515.64 KiB sent
```