### PR TITLE
Add `--listen-port` option to install

### DIFF
--- a/client-core/src/interface.rs
+++ b/client-core/src/interface.rs
@@ -86,7 +86,7 @@ pub fn redeem_invite(
         interface,
         &config.interface.private_key,
         config.interface.address,
-        None,
+        config.interface.listen_port,
         Some((
             &config.server.public_key,
             config.server.internal_endpoint.ip(),

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1259,28 +1259,3 @@ fn run(opts: &Opts) -> Result<(), Error> {
 
     Ok(())
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn install_accepts_listen_port() {
-        let opts = Opts::try_parse_from([
-            "innernet",
-            "install",
-            "invite.toml",
-            "--listen-port",
-            "51821",
-        ])
-        .unwrap();
-
-        assert!(matches!(
-            opts.command,
-            Some(Command::Install {
-                listen_port: Some(51821),
-                ..
-            })
-        ));
-    }
-}

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -70,6 +70,10 @@ enum Command {
         /// Path to the invitation file
         invite: PathBuf,
 
+        /// The local WireGuard listen port
+        #[clap(long)]
+        listen_port: Option<u16>,
+
         #[clap(flatten)]
         hosts: HostsOpts,
 
@@ -274,8 +278,12 @@ fn install(
     install_opts: &InstallOpts,
     nat_opts: &NatOpts,
     invite: &Path,
+    listen_port: Option<u16>,
 ) -> Result<(), Error> {
-    let config = InterfaceConfig::from_file(invite)?;
+    let mut config = InterfaceConfig::from_file(invite)?;
+    if let Some(listen_port) = listen_port {
+        config.interface.listen_port = Some(listen_port);
+    }
 
     let interface_name = if install_opts.default_name {
         config.interface.network_name.clone()
@@ -1144,10 +1152,11 @@ fn run(opts: &Opts) -> Result<(), Error> {
     match command {
         Command::Install {
             invite,
+            listen_port,
             hosts,
             install_opts,
             nat,
-        } => install(opts, &hosts, &install_opts, &nat, &invite)?,
+        } => install(opts, &hosts, &install_opts, &nat, &invite, listen_port)?,
         Command::Show {
             short,
             tree,
@@ -1249,4 +1258,29 @@ fn run(opts: &Opts) -> Result<(), Error> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_accepts_listen_port() {
+        let opts = Opts::try_parse_from([
+            "innernet",
+            "install",
+            "invite.toml",
+            "--listen-port",
+            "51821",
+        ])
+        .unwrap();
+
+        assert!(matches!(
+            opts.command,
+            Some(Command::Install {
+                listen_port: Some(51821),
+                ..
+            })
+        ));
+    }
 }

--- a/docker-tests/run-docker-tests.sh
+++ b/docker-tests/run-docker-tests.sh
@@ -87,6 +87,7 @@ cmd sleep 5
 
 create_peer_docker() {
     local IP=$1
+    local LISTEN_PORT="${2:-}"
     cmd docker create --rm -it \
         --network "$NETWORK" \
         --ip $IP \
@@ -94,6 +95,7 @@ create_peer_docker() {
         --cap-add NET_ADMIN \
         --env RUST_LOG="$CLIENT_RUST_LOG" \
         --env INTERFACE=evilcorp \
+        --env LISTEN_PORT="$LISTEN_PORT" \
         --env INNERNET_ARGS="$INNERNET_ARGS" \
         --env CLIENT_ARGS="$CLIENT_ARGS" \
         innernet /app/start-client.sh
@@ -101,7 +103,7 @@ create_peer_docker() {
 
 info "Starting first peer."
 cmd docker cp "$SERVER_CONTAINER:/app/peer1.toml" "$tmp_dir"
-PEER1_CONTAINER=$(create_peer_docker 172.18.1.2)
+PEER1_CONTAINER=$(create_peer_docker 172.18.1.2 51821)
 info "peer1 started as $PEER1_CONTAINER"
 cmd docker cp "$tmp_dir/peer1.toml" "$PEER1_CONTAINER:/app/invite.toml"
 cmd docker start -a "$PEER1_CONTAINER" | sed -e 's/^/\x1B[0;96mpeer 1\x1B[0m: /' &
@@ -177,6 +179,12 @@ test_short_lived_invitation() {
         --save-config "/app/peer3_2.toml" \
         --invite-expires "30m" \
         --yes
+}
+
+test_install_listen_port() {
+    info "Confirming install applies the requested listen port."
+    cmd docker exec "$PEER1_CONTAINER" bash -c \
+        'innernet $INNERNET_ARGS show "$INTERFACE" | grep -q "listening port.*51821"'
 }
 
 test_simultaneous_redemption() {

--- a/docker-tests/run-docker-tests.sh
+++ b/docker-tests/run-docker-tests.sh
@@ -184,7 +184,7 @@ test_short_lived_invitation() {
 test_install_listen_port() {
     info "Confirming install applies the requested listen port."
     cmd docker exec "$PEER1_CONTAINER" bash -c \
-        'innernet $INNERNET_ARGS show "$INTERFACE" | grep -q "listening port.*51821"'
+        'innernet $INNERNET_ARGS show "$INTERFACE" | grep -Fq "listening port: 51821"'
 }
 
 test_simultaneous_redemption() {

--- a/docker-tests/start-client.sh
+++ b/docker-tests/start-client.sh
@@ -2,8 +2,13 @@
 set -e
 
 INTERFACE="${INTERFACE:-innernet}"
+INSTALL_ARGS=()
+if [[ -n "${LISTEN_PORT:-}" ]]; then
+    INSTALL_ARGS+=(--listen-port "$LISTEN_PORT")
+fi
 
 innernet $INNERNET_ARGS install \
+    "${INSTALL_ARGS[@]}" \
     --name "$INTERFACE" \
     --delete-invite \
     --no-write-hosts \


### PR DESCRIPTION
Adds a long-only `--listen-port` option to invitation redemption and applies the selected port when the WireGuard interface is first created. If the option is omitted, any value already present in the invitation config is preserved.

### Motivation

Peers that require a fixed local WireGuard port currently need to install first and then run `set-listen-port`. Supporting the port during `install` makes initial setup work in one step.

Closes #346.

### Test plan

- `cargo test --workspace --locked --verbose`
- `cargo test --workspace --locked --features v6-test`
- `cargo clippy --workspace --locked --all-targets -- -D warnings`
- `mise exec rust@nightly -- cargo fmt --all -- --check`
- `docker-tests/build-docker-images.sh`
- `docker-tests/run-docker-tests.sh --userspace --verbose` (including a live assertion that peer 1 listens on port 51821)